### PR TITLE
Add item collection view

### DIFF
--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -32,6 +32,17 @@
 		AA9F1C7F265E97C300FC71E0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA8A894F265D778F0005C3BC /* LaunchScreen.storyboard */; };
 		AA9F1CC82661861D00FC71E0 /* ModelsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9F1CC72661861D00FC71E0 /* ModelsSpec.swift */; };
 		AAD1ADEA266189870035EB67 /* GuildedRoseLLCUISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1ADE9266189870035EB67 /* GuildedRoseLLCUISpec.swift */; };
+		AAD1ADEB26618F0B0035EB67 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8944265D778D0005C3BC /* AppDelegate.swift */; };
+		AAD1ADEC26618F0E0035EB67 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8946265D778D0005C3BC /* SceneDelegate.swift */; };
+		AAD1ADED26618F100035EB67 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8948265D778D0005C3BC /* ViewController.swift */; };
+		AAD1ADEE26618F170035EB67 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA8A894A265D778D0005C3BC /* Main.storyboard */; };
+		AAD1ADEF26618F1A0035EB67 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA8A894F265D778F0005C3BC /* LaunchScreen.storyboard */; };
+		AAD1ADF526618F350035EB67 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = AAD1ADF426618F350035EB67 /* Quick */; };
+		AAD1ADF726618F390035EB67 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = AAD1ADF626618F390035EB67 /* Nimble */; };
+		AAD1ADF926618FB70035EB67 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1ADF826618FB70035EB67 /* Item.swift */; };
+		AAD1ADFA26618FF30035EB67 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1ADF826618FB70035EB67 /* Item.swift */; };
+		AAD1ADFB26618FF30035EB67 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1ADF826618FB70035EB67 /* Item.swift */; };
+		AAD1ADFC26618FF40035EB67 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1ADF826618FB70035EB67 /* Item.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +87,7 @@
 		AA9F1CC72661861D00FC71E0 /* ModelsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsSpec.swift; sourceTree = "<group>"; };
 		AA9F1CC92661861D00FC71E0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AAD1ADE9266189870035EB67 /* GuildedRoseLLCUISpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuildedRoseLLCUISpec.swift; sourceTree = "<group>"; };
+		AAD1ADF826618FB70035EB67 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +120,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD1ADF526618F350035EB67 /* Quick in Frameworks */,
+				AAD1ADF726618F390035EB67 /* Nimble in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -180,6 +194,7 @@
 		AA9F1CC0266185BB00FC71E0 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				AAD1ADF826618FB70035EB67 /* Item.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -273,6 +288,10 @@
 				AA9F1CCB2661861D00FC71E0 /* PBXTargetDependency */,
 			);
 			name = ModelsSpec;
+			packageProductDependencies = (
+				AAD1ADF426618F350035EB67 /* Quick */,
+				AAD1ADF626618F390035EB67 /* Nimble */,
+			);
 			productName = ModelsSpec;
 			productReference = AA9F1CC52661861D00FC71E0 /* ModelsSpec.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -363,6 +382,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD1ADEE26618F170035EB67 /* Main.storyboard in Resources */,
+				AAD1ADEF26618F1A0035EB67 /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,6 +394,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD1ADF926618FB70035EB67 /* Item.swift in Sources */,
 				AA8A8949265D778D0005C3BC /* ViewController.swift in Sources */,
 				AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */,
 				AA8A8947265D778D0005C3BC /* SceneDelegate.swift in Sources */,
@@ -383,6 +405,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD1ADFA26618FF30035EB67 /* Item.swift in Sources */,
 				AA9F1C74265E97B000FC71E0 /* AppDelegate.swift in Sources */,
 				AA8A895C265D77900005C3BC /* ViewControllerSpec.swift in Sources */,
 				AA9F1C78265E97B600FC71E0 /* ViewController.swift in Sources */,
@@ -394,6 +417,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD1ADFB26618FF30035EB67 /* Item.swift in Sources */,
 				AAD1ADEA266189870035EB67 /* GuildedRoseLLCUISpec.swift in Sources */,
 				AA9F1C75265E97B100FC71E0 /* AppDelegate.swift in Sources */,
 				AA9F1C79265E97B700FC71E0 /* ViewController.swift in Sources */,
@@ -405,7 +429,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD1ADFC26618FF40035EB67 /* Item.swift in Sources */,
+				AAD1ADEB26618F0B0035EB67 /* AppDelegate.swift in Sources */,
 				AA9F1CC82661861D00FC71E0 /* ModelsSpec.swift in Sources */,
+				AAD1ADED26618F100035EB67 /* ViewController.swift in Sources */,
+				AAD1ADEC26618F0E0035EB67 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -805,6 +833,16 @@
 			productName = Quick;
 		};
 		AA9F1C72265E944700FC71E0 /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA9F1C6A265E941F00FC71E0 /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+		AAD1ADF426618F350035EB67 /* Quick */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA9F1C67265E940B00FC71E0 /* XCRemoteSwiftPackageReference "Quick" */;
+			productName = Quick;
+		};
+		AAD1ADF626618F390035EB67 /* Nimble */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = AA9F1C6A265E941F00FC71E0 /* XCRemoteSwiftPackageReference "Nimble" */;
 			productName = Nimble;

--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -12,10 +12,10 @@
 		05D62CC9266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */; };
 		05D62CCA266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */; };
 		05D62CCC266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
-		05D62CCD266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
-		05D62CCE266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
-		05D62CCF266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
 		AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */; };
+		AA8A10D92672655E00DEE278 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
+		AA8A10DA2672655E00DEE278 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
+		AA8A10DB2672655F00DEE278 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
 		AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8944265D778D0005C3BC /* AppDelegate.swift */; };
 		AA8A8947265D778D0005C3BC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8946265D778D0005C3BC /* SceneDelegate.swift */; };
 		AA8A8949265D778D0005C3BC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8948265D778D0005C3BC /* ViewController.swift */; };
@@ -423,12 +423,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAD1ADFA26618FF30035EB67 /* Item.swift in Sources */,
-				05D62CCD266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
 				AA9F1C74265E97B000FC71E0 /* AppDelegate.swift in Sources */,
 				AA8A895C265D77900005C3BC /* ViewControllerSpec.swift in Sources */,
 				05D62CC8266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
 				AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */,
 				AA9F1C78265E97B600FC71E0 /* ViewController.swift in Sources */,
+				AA8A10D92672655E00DEE278 /* ItemCollectionViewDataSource.swift in Sources */,
 				AA9F1C76265E97B300FC71E0 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -438,7 +438,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAD1ADFB26618FF30035EB67 /* Item.swift in Sources */,
-				05D62CCE266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
+				AA8A10DA2672655E00DEE278 /* ItemCollectionViewDataSource.swift in Sources */,
 				AAD1ADEA266189870035EB67 /* GuildedRoseLLCUISpec.swift in Sources */,
 				AA9F1C75265E97B100FC71E0 /* AppDelegate.swift in Sources */,
 				05D62CC9266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
@@ -452,7 +452,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAD1ADFC26618FF40035EB67 /* Item.swift in Sources */,
-				05D62CCF266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
+				AA8A10DB2672655F00DEE278 /* ItemCollectionViewDataSource.swift in Sources */,
 				AAD1ADEB26618F0B0035EB67 /* AppDelegate.swift in Sources */,
 				AA9F1CC82661861D00FC71E0 /* ModelsSpec.swift in Sources */,
 				05D62CCA266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,

--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		05D62CCD266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
 		05D62CCE266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
 		05D62CCF266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
+		AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */; };
 		AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8944265D778D0005C3BC /* AppDelegate.swift */; };
 		AA8A8947265D778D0005C3BC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8946265D778D0005C3BC /* SceneDelegate.swift */; };
 		AA8A8949265D778D0005C3BC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8948265D778D0005C3BC /* ViewController.swift */; };
@@ -80,6 +81,7 @@
 /* Begin PBXFileReference section */
 		05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewCell.swift; sourceTree = "<group>"; };
 		05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewDataSourceSpec.swift; sourceTree = "<group>"; };
 		AA8A8941265D778D0005C3BC /* GuildedRoseLLC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GuildedRoseLLC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA8A8944265D778D0005C3BC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AA8A8946265D778D0005C3BC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 			children = (
 				AA8A895B265D77900005C3BC /* ViewControllerSpec.swift */,
 				AA8A895D265D77900005C3BC /* Info.plist */,
+				AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */,
 			);
 			path = GuildedRoseLLCSpec;
 			sourceTree = "<group>";
@@ -424,6 +427,7 @@
 				AA9F1C74265E97B000FC71E0 /* AppDelegate.swift in Sources */,
 				AA8A895C265D77900005C3BC /* ViewControllerSpec.swift in Sources */,
 				05D62CC8266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
+				AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */,
 				AA9F1C78265E97B600FC71E0 /* ViewController.swift in Sources */,
 				AA9F1C76265E97B300FC71E0 /* SceneDelegate.swift in Sources */,
 			);

--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05D62CC7266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */; };
+		05D62CC8266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */; };
+		05D62CC9266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */; };
+		05D62CCA266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */; };
+		05D62CCC266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
+		05D62CCD266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
+		05D62CCE266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
+		05D62CCF266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
 		AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8944265D778D0005C3BC /* AppDelegate.swift */; };
 		AA8A8947265D778D0005C3BC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8946265D778D0005C3BC /* SceneDelegate.swift */; };
 		AA8A8949265D778D0005C3BC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8948265D778D0005C3BC /* ViewController.swift */; };
@@ -70,6 +78,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewCell.swift; sourceTree = "<group>"; };
+		05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		AA8A8941265D778D0005C3BC /* GuildedRoseLLC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GuildedRoseLLC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA8A8944265D778D0005C3BC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AA8A8946265D778D0005C3BC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -162,6 +172,8 @@
 				AA8A894D265D778F0005C3BC /* Assets.xcassets */,
 				AA8A894F265D778F0005C3BC /* LaunchScreen.storyboard */,
 				AA8A8952265D778F0005C3BC /* Info.plist */,
+				05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */,
+				05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */,
 			);
 			path = GuildedRoseLLC;
 			sourceTree = "<group>";
@@ -394,6 +406,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				05D62CCC266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
+				05D62CC7266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
 				AAD1ADF926618FB70035EB67 /* Item.swift in Sources */,
 				AA8A8949265D778D0005C3BC /* ViewController.swift in Sources */,
 				AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */,
@@ -406,8 +420,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAD1ADFA26618FF30035EB67 /* Item.swift in Sources */,
+				05D62CCD266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
 				AA9F1C74265E97B000FC71E0 /* AppDelegate.swift in Sources */,
 				AA8A895C265D77900005C3BC /* ViewControllerSpec.swift in Sources */,
+				05D62CC8266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
 				AA9F1C78265E97B600FC71E0 /* ViewController.swift in Sources */,
 				AA9F1C76265E97B300FC71E0 /* SceneDelegate.swift in Sources */,
 			);
@@ -418,8 +434,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAD1ADFB26618FF30035EB67 /* Item.swift in Sources */,
+				05D62CCE266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
 				AAD1ADEA266189870035EB67 /* GuildedRoseLLCUISpec.swift in Sources */,
 				AA9F1C75265E97B100FC71E0 /* AppDelegate.swift in Sources */,
+				05D62CC9266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
 				AA9F1C79265E97B700FC71E0 /* ViewController.swift in Sources */,
 				AA9F1C77265E97B400FC71E0 /* SceneDelegate.swift in Sources */,
 			);
@@ -430,8 +448,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAD1ADFC26618FF40035EB67 /* Item.swift in Sources */,
+				05D62CCF266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
 				AAD1ADEB26618F0B0035EB67 /* AppDelegate.swift in Sources */,
 				AA9F1CC82661861D00FC71E0 /* ModelsSpec.swift in Sources */,
+				05D62CCA266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
 				AAD1ADED26618F100035EB67 /* ViewController.swift in Sources */,
 				AAD1ADEC26618F0E0035EB67 /* SceneDelegate.swift in Sources */,
 			);

--- a/GuildedRoseLLC/AppDelegate.swift
+++ b/GuildedRoseLLC/AppDelegate.swift
@@ -7,6 +7,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        if ProcessInfo.processInfo.arguments.contains("NO_ITEMS_IN_STOCK") {
+            let window = UIWindow(frame: UIScreen.main.bounds)
+            let storyboard = UIStoryboard(name: "Main", bundle: nil)
+            let vc = storyboard.instantiateViewController(identifier: "GreetingViewControllerID") as! GreetingViewController
+            vc.itemCollectionViewDataSource = ItemCollectionViewDataSource(items:[])
+            window.rootViewController = vc
+            window.makeKeyAndVisible()
+            
+        }
         return true
     }
 

--- a/GuildedRoseLLC/AppDelegate.swift
+++ b/GuildedRoseLLC/AppDelegate.swift
@@ -3,8 +3,6 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
@@ -24,7 +22,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
-

--- a/GuildedRoseLLC/AppDelegate.swift
+++ b/GuildedRoseLLC/AppDelegate.swift
@@ -1,10 +1,3 @@
-//
-//  AppDelegate.swift
-//  GuildedRoseLLC
-//
-//  Created by Ethan Whaley on 5/25/21.
-//
-
 import UIKit
 
 @main

--- a/GuildedRoseLLC/AppDelegate.swift
+++ b/GuildedRoseLLC/AppDelegate.swift
@@ -7,15 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        if ProcessInfo.processInfo.arguments.contains("NO_ITEMS_IN_STOCK") {
-            let window = UIWindow(frame: UIScreen.main.bounds)
-            let storyboard = UIStoryboard(name: "Main", bundle: nil)
-            let vc = storyboard.instantiateViewController(identifier: "GreetingViewControllerID") as! GreetingViewController
-            vc.itemCollectionViewDataSource = ItemCollectionViewDataSource(items:[])
-            window.rootViewController = vc
-            window.makeKeyAndVisible()
-            
-        }
+
         return true
     }
 

--- a/GuildedRoseLLC/Base.lproj/Main.storyboard
+++ b/GuildedRoseLLC/Base.lproj/Main.storyboard
@@ -18,18 +18,25 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PSS-sa-E6E">
-                                <rect key="frame" x="75" y="94" width="264" height="49"/>
+                                <rect key="frame" x="0.0" y="94" width="414" height="77.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to the Guilded Rose LLC!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nmN-JN-H6b">
-                                        <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
                                         <accessibility key="accessibilityConfiguration" identifier="Greeting"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Items in stock:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAK-Vs-BOE">
-                                        <rect key="frame" x="0.0" y="28.5" width="264" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="28.5" width="414" height="20.5"/>
                                         <accessibility key="accessibilityConfiguration" identifier="StockAvailabilityHeading"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Items in stock" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YOz-yF-JbC">
+                                        <rect key="frame" x="0.0" y="57" width="414" height="20.5"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="noItemsMessage"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -37,7 +44,7 @@
                                 </subviews>
                             </stackView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Fzc-Sc-AaE">
-                                <rect key="frame" x="20" y="151.5" width="374" height="710.5"/>
+                                <rect key="frame" x="20" y="180" width="374" height="682"/>
                                 <color key="backgroundColor" systemColor="systemIndigoColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="EIA-g4-jzH">
                                     <size key="itemSize" width="128" height="128"/>
@@ -53,7 +60,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JSt-SO-6cq">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JSt-SO-6cq">
                                                     <rect key="frame" x="43.5" y="54" width="41.5" height="20.5"/>
                                                     <color key="backgroundColor" systemColor="systemOrangeColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -79,17 +86,18 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Fzc-Sc-AaE" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="Oak-F3-8gl"/>
-                            <constraint firstItem="PSS-sa-E6E" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="QwQ-io-fPM"/>
-                            <constraint firstItem="PSS-sa-E6E" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="WPk-RC-PW6"/>
                             <constraint firstItem="Fzc-Sc-AaE" firstAttribute="top" secondItem="PSS-sa-E6E" secondAttribute="bottom" constant="8.5" id="XGD-yB-xkm"/>
+                            <constraint firstItem="PSS-sa-E6E" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="Yue-t0-pZs"/>
+                            <constraint firstItem="PSS-sa-E6E" firstAttribute="centerX" secondItem="Fzc-Sc-AaE" secondAttribute="centerX" id="ecb-u6-EtX"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Fzc-Sc-AaE" secondAttribute="trailing" constant="20" id="fbj-55-T2r"/>
-                            <constraint firstItem="PSS-sa-E6E" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="75" id="ug6-cV-xJv"/>
+                            <constraint firstItem="PSS-sa-E6E" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="sw7-Pu-8TD"/>
                             <constraint firstItem="Fzc-Sc-AaE" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="wiP-ek-fGo"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="greeting" destination="nmN-JN-H6b" id="cpL-zQ-T5I"/>
                         <outlet property="itemCollectionView" destination="Fzc-Sc-AaE" id="wOh-Op-yH8"/>
+                        <outlet property="noItemsLabel" destination="YOz-yF-JbC" id="uY2-cB-Uqm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/GuildedRoseLLC/Base.lproj/Main.storyboard
+++ b/GuildedRoseLLC/Base.lproj/Main.storyboard
@@ -5,6 +5,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,25 +17,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PSS-sa-E6E">
-                                <rect key="frame" x="75" y="94" width="263.5" height="77.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PSS-sa-E6E">
+                                <rect key="frame" x="75" y="94" width="264" height="77.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to the Guilded Rose LLC!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nmN-JN-H6b">
-                                        <rect key="frame" x="0.0" y="0.0" width="263.5" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
                                         <accessibility key="accessibilityConfiguration" identifier="Greeting"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Items in stock:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAK-Vs-BOE">
-                                        <rect key="frame" x="0.0" y="28.5" width="263.5" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="28.5" width="264" height="20.5"/>
                                         <accessibility key="accessibilityConfiguration" identifier="StockAvailabilityHeading"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sold out, please check back later." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="erc-ph-Iex">
-                                        <rect key="frame" x="0.0" y="57" width="263.5" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="57" width="264" height="20.5"/>
                                         <accessibility key="accessibilityConfiguration" identifier="SoldOutMessage"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
@@ -42,15 +43,64 @@
                                     </label>
                                 </subviews>
                             </stackView>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Fzc-Sc-AaE">
+                                <rect key="frame" x="20" y="180" width="374" height="682"/>
+                                <color key="backgroundColor" systemColor="systemIndigoColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="EIA-g4-jzH">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cell" id="1aq-tQ-eVo" customClass="ItemCollectionViewCell" customModule="GuildedRoseLLC" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Btb-qB-ZXS" customClass="ItemCollectionViewCell" customModule="GuildedRoseLLC" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JSt-SO-6cq">
+                                                    <rect key="frame" x="43.5" y="54" width="41.5" height="20.5"/>
+                                                    <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="JSt-SO-6cq" firstAttribute="centerY" secondItem="Btb-qB-ZXS" secondAttribute="centerY" id="CM3-qC-wfx"/>
+                                                <constraint firstItem="JSt-SO-6cq" firstAttribute="centerX" secondItem="Btb-qB-ZXS" secondAttribute="centerX" id="fuO-jS-I8B"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <color key="backgroundColor" systemColor="systemTealColor"/>
+                                        <connections>
+                                            <outlet property="itemCell" destination="Btb-qB-ZXS" id="4Xb-KO-8JX"/>
+                                            <outlet property="itemCellLabel" destination="JSt-SO-6cq" id="RhG-t1-f6d"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <connections>
+                                    <outlet property="dataSource" destination="BYZ-38-t0r" id="zC6-vh-Egl"/>
+                                    <outlet property="delegate" destination="BYZ-38-t0r" id="Lwi-r4-kAk"/>
+                                </connections>
+                            </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="Fzc-Sc-AaE" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="Oak-F3-8gl"/>
+                            <constraint firstItem="PSS-sa-E6E" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="QwQ-io-fPM"/>
                             <constraint firstItem="PSS-sa-E6E" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="WPk-RC-PW6"/>
+                            <constraint firstItem="Fzc-Sc-AaE" firstAttribute="top" secondItem="PSS-sa-E6E" secondAttribute="bottom" constant="8.5" id="XGD-yB-xkm"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Fzc-Sc-AaE" secondAttribute="trailing" constant="20" id="fbj-55-T2r"/>
+                            <constraint firstItem="PSS-sa-E6E" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="75" id="ug6-cV-xJv"/>
+                            <constraint firstItem="Fzc-Sc-AaE" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="wiP-ek-fGo"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="Greeting" destination="nmN-JN-H6b" id="DB1-be-yUE"/>
+                        <outlet property="itemCollectionView" destination="Fzc-Sc-AaE" id="wOh-Op-yH8"/>
                         <outlet property="itemsList" destination="erc-ph-Iex" id="djn-YW-jh6"/>
                     </connections>
                 </viewController>
@@ -62,6 +112,15 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemIndigoColor">
+            <color red="0.34509803921568627" green="0.33725490196078434" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemTealColor">
+            <color red="0.35294117647058826" green="0.78431372549019607" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/GuildedRoseLLC/Base.lproj/Main.storyboard
+++ b/GuildedRoseLLC/Base.lproj/Main.storyboard
@@ -51,6 +51,7 @@
                     </view>
                     <connections>
                         <outlet property="Greeting" destination="nmN-JN-H6b" id="DB1-be-yUE"/>
+                        <outlet property="itemsList" destination="erc-ph-Iex" id="djn-YW-jh6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/GuildedRoseLLC/Base.lproj/Main.storyboard
+++ b/GuildedRoseLLC/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PSS-sa-E6E">
-                                <rect key="frame" x="75" y="94" width="264" height="77.5"/>
+                                <rect key="frame" x="75" y="94" width="264" height="49"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to the Guilded Rose LLC!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nmN-JN-H6b">
                                         <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
@@ -34,17 +34,10 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sold out, please check back later." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="erc-ph-Iex">
-                                        <rect key="frame" x="0.0" y="57" width="264" height="20.5"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="SoldOutMessage"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                 </subviews>
                             </stackView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Fzc-Sc-AaE">
-                                <rect key="frame" x="20" y="180" width="374" height="682"/>
+                                <rect key="frame" x="20" y="151.5" width="374" height="710.5"/>
                                 <color key="backgroundColor" systemColor="systemIndigoColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="EIA-g4-jzH">
                                     <size key="itemSize" width="128" height="128"/>
@@ -80,10 +73,6 @@
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
-                                <connections>
-                                    <outlet property="dataSource" destination="BYZ-38-t0r" id="zC6-vh-Egl"/>
-                                    <outlet property="delegate" destination="BYZ-38-t0r" id="Lwi-r4-kAk"/>
-                                </connections>
                             </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -99,9 +88,8 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="Greeting" destination="nmN-JN-H6b" id="DB1-be-yUE"/>
+                        <outlet property="greeting" destination="nmN-JN-H6b" id="cpL-zQ-T5I"/>
                         <outlet property="itemCollectionView" destination="Fzc-Sc-AaE" id="wOh-Op-yH8"/>
-                        <outlet property="itemsList" destination="erc-ph-Iex" id="djn-YW-jh6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/GuildedRoseLLC/ItemCollectionViewCell.swift
+++ b/GuildedRoseLLC/ItemCollectionViewCell.swift
@@ -2,6 +2,5 @@ import UIKit
 
 class ItemCollectionViewCell: UICollectionViewCell {
     @IBOutlet var itemCell: UIView!
-    
     @IBOutlet var itemCellLabel: UILabel!
 }

--- a/GuildedRoseLLC/ItemCollectionViewCell.swift
+++ b/GuildedRoseLLC/ItemCollectionViewCell.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 class ItemCollectionViewCell: UICollectionViewCell {
+    
     @IBOutlet var itemCell: UIView!
     @IBOutlet var itemCellLabel: UILabel!
 }

--- a/GuildedRoseLLC/ItemCollectionViewCell.swift
+++ b/GuildedRoseLLC/ItemCollectionViewCell.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+class ItemCollectionViewCell: UICollectionViewCell {
+    @IBOutlet var itemCell: UIView!
+    
+    @IBOutlet var itemCellLabel: UILabel!
+}

--- a/GuildedRoseLLC/ItemCollectionViewDataSource.swift
+++ b/GuildedRoseLLC/ItemCollectionViewDataSource.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+class ItemCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+    var items: [Item]
+    init(items: [Item]) {
+        self.items = Item.getItems()
+    }
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return Item.getItems().count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath) as! ItemCollectionViewCell
+        
+        cell.itemCellLabel.text = items[indexPath.row].name
+//        let label = UILabel()
+
+
+
+        return cell
+    }
+
+}

--- a/GuildedRoseLLC/ItemCollectionViewDataSource.swift
+++ b/GuildedRoseLLC/ItemCollectionViewDataSource.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 class ItemCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+    
     var items: [Item]
     
     init(items: [Item]) {
@@ -18,5 +19,4 @@ class ItemCollectionViewDataSource: NSObject, UICollectionViewDataSource {
 
         return cell
     }
-
 }

--- a/GuildedRoseLLC/ItemCollectionViewDataSource.swift
+++ b/GuildedRoseLLC/ItemCollectionViewDataSource.swift
@@ -2,21 +2,27 @@ import UIKit
 
 class ItemCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     var items: [Item]
-    init(items: [Item]) {
+    override init() {
         self.items = Item.getItems()
     }
+    
+    init(items: [Item]) {
+        if items.count == 0 {
+            self.items = [Item.noItemsInStock]
+        } else {
+            self.items = items
+        }
+    }
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return Item.getItems().count
+        return items.count
+        // if no items make 1 cell
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath) as! ItemCollectionViewCell
-        
         cell.itemCellLabel.text = items[indexPath.row].name
-//        let label = UILabel()
-
-
 
         return cell
     }

--- a/GuildedRoseLLC/ItemCollectionViewDataSource.swift
+++ b/GuildedRoseLLC/ItemCollectionViewDataSource.swift
@@ -2,21 +2,13 @@ import UIKit
 
 class ItemCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     var items: [Item]
-    override init() {
-        self.items = Item.getItems()
-    }
     
     init(items: [Item]) {
-        if items.count == 0 {
-            self.items = [Item.noItemsInStock]
-        } else {
-            self.items = items
-        }
+        self.items = items
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return items.count
-        // if no items make 1 cell
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/GuildedRoseLLC/Models/Item.swift
+++ b/GuildedRoseLLC/Models/Item.swift
@@ -1,5 +1,29 @@
 import Foundation
 
 public struct Item {
+    public init(name: String) {
+        self.name = name
+    }
     public let name: String
+    
+    public static func getItems() -> [Item] {
+        return testData
+    }
+}
+
+extension Item:Equatable{
+    public static func == (lhs:Item, rhs:Item) -> Bool {
+        return lhs.name == rhs.name
+    }
+}
+
+extension Item {
+    static var testData = [
+        Item(name: "Foo"),
+        Item(name: "Bar"),
+        Item(name: "FooBar"),
+        Item(name: "Lorem"),
+        Item(name: "Ipsum"),
+        Item(name: "VeniVidiVici"),
+    ]
 }

--- a/GuildedRoseLLC/Models/Item.swift
+++ b/GuildedRoseLLC/Models/Item.swift
@@ -1,13 +1,24 @@
-import Foundation
-
-public struct Item {
+struct Item {
     public init(name: String) {
         self.name = name
     }
     public let name: String
     
     public static func getItems() -> [Item] {
-        return testData
+
+        guard CommandLine.arguments.count > 1 else {
+            return testData
+        }
+        switch CommandLine.arguments[1] {
+        case "NO_ITEMS_IN_STOCK":
+            return []
+        case "SINGLE_TEST_ITEM":
+            return [singleTestItem]
+        case "THREE_TEST_ITEMS":
+            return [singleTestItem, singleTestItem, singleTestItem,]
+        default:
+            return testData
+        }
     }
     
 }
@@ -27,5 +38,6 @@ extension Item {
         Item(name: "Ipsum"),
         Item(name: "VeniVidiVici"),
     ]
-    static var noItemsInStock = Item(name: "Sold out, please check back later")
+//    static var noItemsInStock = Item(name: "Sold out, please check back later")
+    static var singleTestItem = Item(name: "Foo")
 }

--- a/GuildedRoseLLC/Models/Item.swift
+++ b/GuildedRoseLLC/Models/Item.swift
@@ -1,7 +1,9 @@
 struct Item {
+    
     public init(name: String) {
         self.name = name
     }
+    
     public let name: String
     
     public static func getItems() -> [Item] {
@@ -20,7 +22,6 @@ struct Item {
             return testData
         }
     }
-    
 }
 
 extension Item:Equatable{
@@ -38,6 +39,5 @@ extension Item {
         Item(name: "Ipsum"),
         Item(name: "VeniVidiVici"),
     ]
-//    static var noItemsInStock = Item(name: "Sold out, please check back later")
     static var singleTestItem = Item(name: "Foo")
 }

--- a/GuildedRoseLLC/Models/Item.swift
+++ b/GuildedRoseLLC/Models/Item.swift
@@ -9,6 +9,7 @@ public struct Item {
     public static func getItems() -> [Item] {
         return testData
     }
+    
 }
 
 extension Item:Equatable{
@@ -26,4 +27,5 @@ extension Item {
         Item(name: "Ipsum"),
         Item(name: "VeniVidiVici"),
     ]
+    static var noItemsInStock = Item(name: "Sold out, please check back later")
 }

--- a/GuildedRoseLLC/Models/Item.swift
+++ b/GuildedRoseLLC/Models/Item.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public struct Item {
+    public let name: String
+}

--- a/GuildedRoseLLC/SceneDelegate.swift
+++ b/GuildedRoseLLC/SceneDelegate.swift
@@ -4,7 +4,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -39,7 +38,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
-

--- a/GuildedRoseLLC/SceneDelegate.swift
+++ b/GuildedRoseLLC/SceneDelegate.swift
@@ -1,10 +1,3 @@
-//
-//  SceneDelegate.swift
-//  GuildedRoseLLC
-//
-//  Created by Ethan Whaley on 5/25/21.
-//
-
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/GuildedRoseLLC/ViewController.swift
+++ b/GuildedRoseLLC/ViewController.swift
@@ -1,26 +1,20 @@
 import UIKit
 
-public class GreetingViewController: UIViewController {
+public class GreetingViewController: UIViewController, UICollectionViewDelegate {
     
     @IBOutlet public var greeting: UILabel!
-    public var items:[Item] = [Item(name:"Sold out, please check back later")]
-    @IBOutlet public var itemsList: UILabel!
     @IBOutlet public var itemCollectionView: UICollectionView!
-    var itemCollectionViewDataSource = ItemCollectionViewDataSource(items: [Item(name: "FooBar")])
+    var itemCollectionViewDataSource = ItemCollectionViewDataSource()
     
     override public func viewDidLoad() {
         super.viewDidLoad()
         itemCollectionView.dataSource = itemCollectionViewDataSource
+        itemCollectionView.delegate = self
         greeting = UILabel()
         greeting.accessibilityIdentifier = "Greeting"
         greeting.text = "Welcome to the Guilded Rose LLC!"
-        itemsList = UILabel()
         
-        
-        
-        let itemsText = items.map {$0.name}.joined(separator: ", ")
-
-        itemsList.text = itemsText
+        itemCollectionView.accessibilityIdentifier = "itemCollectionView"
     }
 
 }

--- a/GuildedRoseLLC/ViewController.swift
+++ b/GuildedRoseLLC/ViewController.swift
@@ -3,13 +3,17 @@ import UIKit
 public class GreetingViewController: UIViewController {
     
     @IBOutlet var greeting: UILabel!
+    var items:[Item] = [Item(name:"Sold out, please check back later")]
+    @IBOutlet var itemsList: UILabel!
+    
     
     override public func viewDidLoad() {
         super.viewDidLoad()
         greeting = UILabel()
         greeting.accessibilityIdentifier = "Greeting"
         greeting.text = "Welcome to the Guilded Rose LLC!"
+        itemsList = UILabel()
+        itemsList.text = items[0].name
     }
 
 }
-

--- a/GuildedRoseLLC/ViewController.swift
+++ b/GuildedRoseLLC/ViewController.swift
@@ -2,18 +2,25 @@ import UIKit
 
 public class GreetingViewController: UIViewController {
     
-    @IBOutlet var greeting: UILabel!
-    var items:[Item] = [Item(name:"Sold out, please check back later")]
-    @IBOutlet var itemsList: UILabel!
-    
+    @IBOutlet public var greeting: UILabel!
+    public var items:[Item] = [Item(name:"Sold out, please check back later")]
+    @IBOutlet public var itemsList: UILabel!
+    @IBOutlet public var itemCollectionView: UICollectionView!
+    var itemCollectionViewDataSource = ItemCollectionViewDataSource(items: [Item(name: "FooBar")])
     
     override public func viewDidLoad() {
         super.viewDidLoad()
+        itemCollectionView.dataSource = itemCollectionViewDataSource
         greeting = UILabel()
         greeting.accessibilityIdentifier = "Greeting"
         greeting.text = "Welcome to the Guilded Rose LLC!"
         itemsList = UILabel()
-        itemsList.text = items[0].name
+        
+        
+        
+        let itemsText = items.map {$0.name}.joined(separator: ", ")
+
+        itemsList.text = itemsText
     }
 
 }

--- a/GuildedRoseLLC/ViewController.swift
+++ b/GuildedRoseLLC/ViewController.swift
@@ -4,15 +4,27 @@ public class GreetingViewController: UIViewController, UICollectionViewDelegate 
     
     @IBOutlet public var greeting: UILabel!
     @IBOutlet public var itemCollectionView: UICollectionView!
-    var itemCollectionViewDataSource = ItemCollectionViewDataSource()
-    
+    @IBOutlet public var noItemsLabel: UILabel!
+    var datasource: ItemCollectionViewDataSource?
+    func toggleListDisplay(data: [Item]) {
+
+        if data.isEmpty {
+            itemCollectionView.isHidden = true
+            noItemsLabel.isHidden = false
+        } else {
+            itemCollectionView.isHidden = false
+            noItemsLabel.isHidden = true
+        }
+    }
     override public func viewDidLoad() {
         super.viewDidLoad()
-        itemCollectionView.dataSource = itemCollectionViewDataSource
+        let data = Item.getItems()
+        datasource = ItemCollectionViewDataSource(items: data)
+        itemCollectionView.dataSource = datasource
         itemCollectionView.delegate = self
-        greeting = UILabel()
+        toggleListDisplay(data: data)
+        
         greeting.accessibilityIdentifier = "Greeting"
-        greeting.text = "Welcome to the Guilded Rose LLC!"
         
         itemCollectionView.accessibilityIdentifier = "itemCollectionView"
     }

--- a/GuildedRoseLLC/ViewController.swift
+++ b/GuildedRoseLLC/ViewController.swift
@@ -5,9 +5,9 @@ public class GreetingViewController: UIViewController, UICollectionViewDelegate 
     @IBOutlet public var greeting: UILabel!
     @IBOutlet public var itemCollectionView: UICollectionView!
     @IBOutlet public var noItemsLabel: UILabel!
+    
     var datasource: ItemCollectionViewDataSource?
     func toggleListDisplay(data: [Item]) {
-
         if data.isEmpty {
             itemCollectionView.isHidden = true
             noItemsLabel.isHidden = false
@@ -16,6 +16,7 @@ public class GreetingViewController: UIViewController, UICollectionViewDelegate 
             noItemsLabel.isHidden = true
         }
     }
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
         let data = Item.getItems()
@@ -25,8 +26,6 @@ public class GreetingViewController: UIViewController, UICollectionViewDelegate 
         toggleListDisplay(data: data)
         
         greeting.accessibilityIdentifier = "Greeting"
-        
         itemCollectionView.accessibilityIdentifier = "itemCollectionView"
     }
-
 }

--- a/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
+++ b/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
@@ -1,0 +1,41 @@
+import Quick
+import Nimble
+import GuildedRoseLLC
+import XCTest
+
+class ItemCollectionViewDataSourceSpec: QuickSpec {
+    override func spec() {
+        
+        
+        func buildCollectionView() -> UICollectionView {
+            let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 0, height: 0), collectionViewLayout: UICollectionViewLayout())
+            collectionView.register(ItemCollectionViewCell.self, forCellWithReuseIdentifier: "cell")
+            
+            
+
+            return collectionView
+        }
+        
+        describe("the number of items") {
+            it("has a single item, the not in stock message") {
+                let dataSource = ItemCollectionViewDataSource(items: [])
+                let collectionView = buildCollectionView()
+                let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
+                expect(numberOfItems).to(equal(1))
+            }
+            it("has one item") {
+                let dataSource = ItemCollectionViewDataSource(items: [Item(name: "Foo")])
+                let collectionView = buildCollectionView()
+                let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
+                expect(numberOfItems).to(equal(1))
+            }
+            it("has six items") {
+                let dataSource = ItemCollectionViewDataSource(items: Item.testData)
+                let collectionView = buildCollectionView()
+
+                let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
+                expect(numberOfItems).to(equal(6))
+            }
+        }
+    }
+}

--- a/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
+++ b/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
@@ -4,15 +4,13 @@ import GuildedRoseLLC
 import XCTest
 
 class ItemCollectionViewDataSourceSpec: QuickSpec {
+    
     override func spec() {
-        
         
         func buildCollectionView() -> UICollectionView {
             let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 0, height: 0), collectionViewLayout: UICollectionViewLayout())
             collectionView.register(ItemCollectionViewCell.self, forCellWithReuseIdentifier: "cell")
             
-            
-
             return collectionView
         }
         
@@ -21,19 +19,23 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
                 let dataSource = ItemCollectionViewDataSource(items: [])
                 let collectionView = buildCollectionView()
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
+                
                 expect(numberOfItems).to(equal(0))
             }
+            
             it("has one item") {
                 let dataSource = ItemCollectionViewDataSource(items: [Item(name: "Foo")])
                 let collectionView = buildCollectionView()
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
+                
                 expect(numberOfItems).to(equal(1))
             }
+            
             it("has six items") {
                 let dataSource = ItemCollectionViewDataSource(items: Item.testData)
                 let collectionView = buildCollectionView()
-
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
+                
                 expect(numberOfItems).to(equal(6))
             }
         }

--- a/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
+++ b/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
@@ -17,11 +17,11 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
         }
         
         describe("the number of items") {
-            it("has a single item, the not in stock message") {
+            it("has no items") {
                 let dataSource = ItemCollectionViewDataSource(items: [])
                 let collectionView = buildCollectionView()
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
-                expect(numberOfItems).to(equal(1))
+                expect(numberOfItems).to(equal(0))
             }
             it("has one item") {
                 let dataSource = ItemCollectionViewDataSource(items: [Item(name: "Foo")])

--- a/GuildedRoseLLCSpec/ViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ViewControllerSpec.swift
@@ -6,8 +6,16 @@ import XCTest
 class ViewControllerSpec: QuickSpec {
     override func spec() {
         describe("Loading the view") {
+            var controller: GuildedRoseLLC.GreetingViewController!
+            beforeEach {
+                controller = GuildedRoseLLC.GreetingViewController()
+                let itemCollectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 0, height: 0), collectionViewLayout: UICollectionViewLayout())
+                controller.itemCollectionView = itemCollectionView
+//                controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "GreetingViewControllerID") as? GuildedRoseLLC.GreetingViewController
+            }
             it("updates the greeting text") {
-                let controller = GreetingViewController()
+
+
                 let greeting = UILabel()
                 greeting.text = "Original Text"
                 controller.greeting = greeting
@@ -16,12 +24,24 @@ class ViewControllerSpec: QuickSpec {
 
                 expect(controller.greeting.text).to(equal("Welcome to the Guilded Rose LLC!"))
             }
-            it("updates the items list for no items") {
-                let controller = GreetingViewController()
-                controller.items[0] = Item(name: "Concert Tickets")
+            it("displays the no items message when there are zero items") {
+                
+                controller.viewDidLoad()
+                
+                expect(controller.itemsList.text).to(equal("Sold out, please check back later"))
+            }
+            it("updates the items list with one item") {
+                controller.items[0] = GuildedRoseLLC.Item(name: "Concert Tickets")
                 controller.viewDidLoad()
 
                 expect(controller.itemsList.text).to(equal("Concert Tickets"))
+            }
+            it("updates the items list with many items") {
+                controller.items = [GuildedRoseLLC.Item(name: "Foo"), GuildedRoseLLC.Item(name:"Bar"), GuildedRoseLLC.Item(name:"FooBar")]
+                
+                controller.viewDidLoad()
+                
+                expect(controller.itemsList.text).to(equal("Foo, Bar, FooBar"))
             }
         }
     }

--- a/GuildedRoseLLCSpec/ViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ViewControllerSpec.swift
@@ -11,38 +11,16 @@ class ViewControllerSpec: QuickSpec {
                 controller = GuildedRoseLLC.GreetingViewController()
                 let itemCollectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 0, height: 0), collectionViewLayout: UICollectionViewLayout())
                 controller.itemCollectionView = itemCollectionView
-//                controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "GreetingViewControllerID") as? GuildedRoseLLC.GreetingViewController
             }
-            it("updates the greeting text") {
+            describe("loading the view") {
+                it("sets a data source") {
+                    
+                    controller.viewDidLoad()
+                    
+                    expect(controller.itemCollectionView.dataSource).notTo(beNil())
+                }
+            }
 
-
-                let greeting = UILabel()
-                greeting.text = "Original Text"
-                controller.greeting = greeting
-                
-                controller.viewDidLoad()
-
-                expect(controller.greeting.text).to(equal("Welcome to the Guilded Rose LLC!"))
-            }
-            it("displays the no items message when there are zero items") {
-                
-                controller.viewDidLoad()
-                
-                expect(controller.itemsList.text).to(equal("Sold out, please check back later"))
-            }
-            it("updates the items list with one item") {
-                controller.items[0] = GuildedRoseLLC.Item(name: "Concert Tickets")
-                controller.viewDidLoad()
-
-                expect(controller.itemsList.text).to(equal("Concert Tickets"))
-            }
-            it("updates the items list with many items") {
-                controller.items = [GuildedRoseLLC.Item(name: "Foo"), GuildedRoseLLC.Item(name:"Bar"), GuildedRoseLLC.Item(name:"FooBar")]
-                
-                controller.viewDidLoad()
-                
-                expect(controller.itemsList.text).to(equal("Foo, Bar, FooBar"))
-            }
         }
     }
 }

--- a/GuildedRoseLLCSpec/ViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ViewControllerSpec.swift
@@ -16,6 +16,13 @@ class ViewControllerSpec: QuickSpec {
 
                 expect(controller.greeting.text).to(equal("Welcome to the Guilded Rose LLC!"))
             }
+            it("updates the items list for no items") {
+                let controller = GreetingViewController()
+                controller.items[0] = Item(name: "Concert Tickets")
+                controller.viewDidLoad()
+
+                expect(controller.itemsList.text).to(equal("Concert Tickets"))
+            }
         }
     }
 }

--- a/GuildedRoseLLCSpec/ViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ViewControllerSpec.swift
@@ -4,16 +4,18 @@ import GuildedRoseLLC
 import XCTest
 
 class ViewControllerSpec: QuickSpec {
+    
     override func spec() {
+        
         describe("Loading the view") {
             var controller: GuildedRoseLLC.GreetingViewController!
+            
             beforeEach {
                 controller = GuildedRoseLLC.GreetingViewController()
                 let itemCollectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 0, height: 0), collectionViewLayout: UICollectionViewLayout())
                 controller.itemCollectionView = itemCollectionView
                 controller.greeting = UILabel()
                 controller.noItemsLabel = UILabel()
-                
             }
             describe("loading the view") {
                 it("sets a data source") {
@@ -23,7 +25,6 @@ class ViewControllerSpec: QuickSpec {
                     expect(controller.itemCollectionView.dataSource).notTo(beNil())
                 }
             }
-
         }
     }
 }

--- a/GuildedRoseLLCSpec/ViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ViewControllerSpec.swift
@@ -11,6 +11,9 @@ class ViewControllerSpec: QuickSpec {
                 controller = GuildedRoseLLC.GreetingViewController()
                 let itemCollectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 0, height: 0), collectionViewLayout: UICollectionViewLayout())
                 controller.itemCollectionView = itemCollectionView
+                controller.greeting = UILabel()
+                controller.noItemsLabel = UILabel()
+                
             }
             describe("loading the view") {
                 it("sets a data source") {

--- a/GuildedRoseLLCUISpec/GuildedRoseLLCUISpec.swift
+++ b/GuildedRoseLLCUISpec/GuildedRoseLLCUISpec.swift
@@ -4,89 +4,76 @@ import XCTest
 import GuildedRoseLLC
 
 class GuildedRoseLLCSpec: QuickSpec {
+
     override func spec() {
         var app: XCUIApplication!
+        func launchWithCommandArgument(argument: String, app: XCUIApplication)
+        {
+            app.launchArguments.append(argument)
+            app.launch()
+
+        }
         
         describe("greeting message") {
-            it("displays the welcome greeting"){
+            it("displays the welcome header"){
                 app = XCUIApplication()
                 app.launch()
                 let labelElement = app.staticTexts["Greeting"]
+                let labelElement2 = app.staticTexts["StockAvailabilityHeading"]
                 
                 expect(labelElement.exists).to(beTrue())
                 expect(labelElement.label).to(equal("Welcome to the Guilded Rose LLC!"))
-            }
-        }
-        
-        describe("Items in stock heading") {
-            it("displays 'Items in stock' text") {
-                app = XCUIApplication()
-                app.launch()
-                let labelElement = app.staticTexts["StockAvailabilityHeading"]
                 
-                expect(labelElement.exists).to(beTrue())
-                expect(labelElement.label).to(equal("Items in stock:"))
+                expect(labelElement2.exists).to(beTrue())
+                expect(labelElement2.label).to(equal("Items in stock:"))
             }
         }
         
-        describe("Items message") {
+        describe("Items view") {
             context("When there are no items in stock") {
-                it("displays sold out message") {
+                it("hides the itemsCollectionview and shows the no items message") {
+                    
                     app = XCUIApplication()
-                    app.launchArguments.append("NO_ITEMS_IN_STOCK")
-                    app.launch()
-                    
-//                    print (app.debugDescription)
+                    launchWithCommandArgument(argument: "NO_ITEMS_IN_STOCK", app: app)
+
                     let view = app.collectionViews["itemCollectionView"]
+                    let noItemsMessage = app.staticTexts["noItemsMessage"]
                     
+                    expect(view.isHittable).to(equal(false))
+                    expect(noItemsMessage.isHittable).to(equal(true))
+
+                }
+            }
+            
+            context("With one item"){
+                it("displays the single item and doesn't display no items message") {
+                    app = XCUIApplication()
+                    launchWithCommandArgument(argument: "SINGLE_TEST_ITEM", app: app)
+
+                    let view = app.collectionViews["itemCollectionView"]
+                    let cells = view.descendants(matching: XCUIElement.ElementType.staticText).allElementsBoundByIndex
+                    let noItemsMessage = app.staticTexts["noItemsMessage"]
+                    
+                    expect(view.isHittable).to(equal(true))
+                    expect(noItemsMessage.isHittable).to(equal(false))
+                    expect(cells.count).to(equal(1))
+                    
+
+                    
+                }
+            }
+            
+            context("With three items"){
+                it("displays the three items") {
+                    app = XCUIApplication()
+                    launchWithCommandArgument(argument: "THREE_TEST_ITEMS", app: app)
+
+                    let view = app.collectionViews["itemCollectionView"]
                     let cells = view.descendants(matching: XCUIElement.ElementType.staticText).allElementsBoundByIndex
                     
-                    expect(cells.count).to(equal(1))
-                    expect(cells[0].label).to(equal("Sold out, please check back later"))
-                    
-                    
-//                    let labelElement = app.staticTexts["SoldOutMessage"]
-//                    expect(labelElement.exists).to(beTrue())
-//                    expect(labelElement.label).to(equal("Sold out, please check back later."))
+                    expect(cells.count).to(equal(3))
                 }
             }
         }
-        //        it("updates the greeting text") {
-        //
-        //
-        //            let greeting = UILabel()
-        //            greeting.text = "Original Text"
-        //            controller.greeting = greeting
-        //
-        //            controller.viewDidLoad()
-        //
-        //            expect(controller.greeting.text).to(equal("Welcome to the Guilded Rose LLC!"))
-        //        }
-        //
-        //        it("displays the no items message when there are zero items") {
-        //            let datasource = ItemCollectionViewDataSource(items:[Item(name:"foobar")])
-        //
-        //            controller.itemCollectionView.dataSource = datasource
-        ////                controller.viewDidLoad()
-        //
-        //            expect(controller
-        //                    .itemCollectionView
-        //                    .cellForItem(at:IndexPath(row: 0, section: 0)))
-        //                .to(beNil())
-        //
-        //        }
-        //        it("updates the items list with one item") {
-        //            controller.items[0] = GuildedRoseLLC.Item(name: "Concert Tickets")
-        //            controller.viewDidLoad()
-        //
-        //            expect(controller.itemsList.text).to(equal("Concert Tickets"))
-        //        }
-        //        it("updates the items list with many items") {
-        //            controller.items = [GuildedRoseLLC.Item(name: "Foo"), GuildedRoseLLC.Item(name:"Bar"), GuildedRoseLLC.Item(name:"FooBar")]
-        //
-        //            controller.viewDidLoad()
-        //
-        //            expect(controller.itemsList.text).to(equal("Foo, Bar, FooBar"))
-        //        }
     }
 }

--- a/GuildedRoseLLCUISpec/GuildedRoseLLCUISpec.swift
+++ b/GuildedRoseLLCUISpec/GuildedRoseLLCUISpec.swift
@@ -6,7 +6,9 @@ import GuildedRoseLLC
 class GuildedRoseLLCSpec: QuickSpec {
 
     override func spec() {
+        
         var app: XCUIApplication!
+        
         func launchWithCommandArgument(argument: String, app: XCUIApplication)
         {
             app.launchArguments.append(argument)
@@ -32,16 +34,13 @@ class GuildedRoseLLCSpec: QuickSpec {
         describe("Items view") {
             context("When there are no items in stock") {
                 it("hides the itemsCollectionview and shows the no items message") {
-                    
                     app = XCUIApplication()
                     launchWithCommandArgument(argument: "NO_ITEMS_IN_STOCK", app: app)
-
                     let view = app.collectionViews["itemCollectionView"]
                     let noItemsMessage = app.staticTexts["noItemsMessage"]
                     
                     expect(view.isHittable).to(equal(false))
                     expect(noItemsMessage.isHittable).to(equal(true))
-
                 }
             }
             
@@ -49,7 +48,6 @@ class GuildedRoseLLCSpec: QuickSpec {
                 it("displays the single item and doesn't display no items message") {
                     app = XCUIApplication()
                     launchWithCommandArgument(argument: "SINGLE_TEST_ITEM", app: app)
-
                     let view = app.collectionViews["itemCollectionView"]
                     let cells = view.descendants(matching: XCUIElement.ElementType.staticText).allElementsBoundByIndex
                     let noItemsMessage = app.staticTexts["noItemsMessage"]
@@ -57,9 +55,6 @@ class GuildedRoseLLCSpec: QuickSpec {
                     expect(view.isHittable).to(equal(true))
                     expect(noItemsMessage.isHittable).to(equal(false))
                     expect(cells.count).to(equal(1))
-                    
-
-                    
                 }
             }
             
@@ -67,7 +62,6 @@ class GuildedRoseLLCSpec: QuickSpec {
                 it("displays the three items") {
                     app = XCUIApplication()
                     launchWithCommandArgument(argument: "THREE_TEST_ITEMS", app: app)
-
                     let view = app.collectionViews["itemCollectionView"]
                     let cells = view.descendants(matching: XCUIElement.ElementType.staticText).allElementsBoundByIndex
                     

--- a/GuildedRoseLLCUISpec/GuildedRoseLLCUISpec.swift
+++ b/GuildedRoseLLCUISpec/GuildedRoseLLCUISpec.swift
@@ -6,14 +6,13 @@ import GuildedRoseLLC
 class GuildedRoseLLCSpec: QuickSpec {
     override func spec() {
         var app: XCUIApplication!
-        beforeEach {
-            app = XCUIApplication()
-            app.launch()
-        }
         
         describe("greeting message") {
             it("displays the welcome greeting"){
+                app = XCUIApplication()
+                app.launch()
                 let labelElement = app.staticTexts["Greeting"]
+                
                 expect(labelElement.exists).to(beTrue())
                 expect(labelElement.label).to(equal("Welcome to the Guilded Rose LLC!"))
             }
@@ -21,7 +20,10 @@ class GuildedRoseLLCSpec: QuickSpec {
         
         describe("Items in stock heading") {
             it("displays 'Items in stock' text") {
+                app = XCUIApplication()
+                app.launch()
                 let labelElement = app.staticTexts["StockAvailabilityHeading"]
+                
                 expect(labelElement.exists).to(beTrue())
                 expect(labelElement.label).to(equal("Items in stock:"))
             }
@@ -30,11 +32,61 @@ class GuildedRoseLLCSpec: QuickSpec {
         describe("Items message") {
             context("When there are no items in stock") {
                 it("displays sold out message") {
-                    let labelElement = app.staticTexts["SoldOutMessage"]
-                    expect(labelElement.exists).to(beTrue())
-                    expect(labelElement.label).to(equal("Sold out, please check back later."))
+                    app = XCUIApplication()
+                    app.launchArguments.append("NO_ITEMS_IN_STOCK")
+                    app.launch()
+                    
+//                    print (app.debugDescription)
+                    let view = app.collectionViews["itemCollectionView"]
+                    
+                    let cells = view.descendants(matching: XCUIElement.ElementType.staticText).allElementsBoundByIndex
+                    
+                    expect(cells.count).to(equal(1))
+                    expect(cells[0].label).to(equal("Sold out, please check back later"))
+                    
+                    
+//                    let labelElement = app.staticTexts["SoldOutMessage"]
+//                    expect(labelElement.exists).to(beTrue())
+//                    expect(labelElement.label).to(equal("Sold out, please check back later."))
                 }
             }
         }
+        //        it("updates the greeting text") {
+        //
+        //
+        //            let greeting = UILabel()
+        //            greeting.text = "Original Text"
+        //            controller.greeting = greeting
+        //
+        //            controller.viewDidLoad()
+        //
+        //            expect(controller.greeting.text).to(equal("Welcome to the Guilded Rose LLC!"))
+        //        }
+        //
+        //        it("displays the no items message when there are zero items") {
+        //            let datasource = ItemCollectionViewDataSource(items:[Item(name:"foobar")])
+        //
+        //            controller.itemCollectionView.dataSource = datasource
+        ////                controller.viewDidLoad()
+        //
+        //            expect(controller
+        //                    .itemCollectionView
+        //                    .cellForItem(at:IndexPath(row: 0, section: 0)))
+        //                .to(beNil())
+        //
+        //        }
+        //        it("updates the items list with one item") {
+        //            controller.items[0] = GuildedRoseLLC.Item(name: "Concert Tickets")
+        //            controller.viewDidLoad()
+        //
+        //            expect(controller.itemsList.text).to(equal("Concert Tickets"))
+        //        }
+        //        it("updates the items list with many items") {
+        //            controller.items = [GuildedRoseLLC.Item(name: "Foo"), GuildedRoseLLC.Item(name:"Bar"), GuildedRoseLLC.Item(name:"FooBar")]
+        //
+        //            controller.viewDidLoad()
+        //
+        //            expect(controller.itemsList.text).to(equal("Foo, Bar, FooBar"))
+        //        }
     }
 }

--- a/ModelsSpec/ModelsSpec.swift
+++ b/ModelsSpec/ModelsSpec.swift
@@ -1,1 +1,15 @@
+import Quick
+import Nimble
+import GuildedRoseLLC
+
+class ItemSpec: QuickSpec {
+    override func spec() {
+        describe("an Item") {
+            it("sets the name on instantiation") {
+                let brie = Item(name: "Brie")
+                expect(brie.name).to(equal("Brie"))
+            }
+        }
+    }
+}
 

--- a/ModelsSpec/ModelsSpec.swift
+++ b/ModelsSpec/ModelsSpec.swift
@@ -3,22 +3,21 @@ import Nimble
 import GuildedRoseLLC
 
 class ItemSpec: QuickSpec {
+    
     override func spec() {
+        
         describe("an Item") {
             it("sets the name on instantiation") {
                 let brie = Item(name: "Brie")
+                
                 expect(brie.name).to(equal("Brie"))
             }
         }
+        
         describe("fetch items") {
             it("returns a list of items") {
                 expect(Item.getItems()).to(equal(Item.testData))
-                
             }
         }
     }
 }
-
-
-
-//let itemsList = [Item(name: "Foo"), Item(name:"Bar"), Item(name:"FooBar")]

--- a/ModelsSpec/ModelsSpec.swift
+++ b/ModelsSpec/ModelsSpec.swift
@@ -10,6 +10,15 @@ class ItemSpec: QuickSpec {
                 expect(brie.name).to(equal("Brie"))
             }
         }
+        describe("fetch items") {
+            it("returns a list of items") {
+                expect(Item.getItems()).to(equal(Item.testData))
+                
+            }
+        }
     }
 }
 
+
+
+//let itemsList = [Item(name: "Foo"), Item(name:"Bar"), Item(name:"FooBar")]


### PR DESCRIPTION
## Summary 

The `add-item-collection-view` branch adds a collection view to the ios app in order for the user to view the available store items. Currently, the items are not being retrieved from a database, they are hardcoded.

Figure 1: View when there are items available.
<img width="355" alt="manyItemsRendered" src="https://user-images.githubusercontent.com/43938783/121715590-aebcfb00-caa4-11eb-9ea5-5ef40dae3c3a.png">

Figure 2. View when there are no items available. 
<img width="353" alt="noItemsRendered" src="https://user-images.githubusercontent.com/43938783/121715674-c5635200-caa4-11eb-9a3a-0030fa18e69e.png">