### PR TITLE
Add RemoteItemRepository to make network Call

### DIFF
--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AA9F1C6F265E943A00FC71E0 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = AA9F1C6E265E943A00FC71E0 /* Nimble */; };
 		AA9F1CC82661861D00FC71E0 /* ModelsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9F1CC72661861D00FC71E0 /* ModelsSpec.swift */; };
 		AABFE13F2683758600B6344C /* StaticItemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABFE13E2683758600B6344C /* StaticItemRepository.swift */; };
+		AABFE14126839C7C00B6344C /* RemoteItemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABFE14026839C7C00B6344C /* RemoteItemRepository.swift */; };
 		AAD1ADF526618F350035EB67 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = AAD1ADF426618F350035EB67 /* Quick */; };
 		AAD1ADF726618F390035EB67 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = AAD1ADF626618F390035EB67 /* Nimble */; };
 		AAD1ADF926618FB70035EB67 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1ADF826618FB70035EB67 /* Item.swift */; };
@@ -70,6 +71,7 @@
 		AA9F1CC72661861D00FC71E0 /* ModelsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsSpec.swift; sourceTree = "<group>"; };
 		AA9F1CC92661861D00FC71E0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AABFE13E2683758600B6344C /* StaticItemRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticItemRepository.swift; sourceTree = "<group>"; };
+		AABFE14026839C7C00B6344C /* RemoteItemRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteItemRepository.swift; sourceTree = "<group>"; };
 		AAD1ADF826618FB70035EB67 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -182,6 +184,7 @@
 				05B4B6D9268272C100D0EFA6 /* ItemRepository.swift */,
 				AA8A8948265D778D0005C3BC /* ItemsViewController.swift */,
 				AABFE13E2683758600B6344C /* StaticItemRepository.swift */,
+				AABFE14026839C7C00B6344C /* RemoteItemRepository.swift */,
 			);
 			path = Items;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 			files = (
 				05D62CCC266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
 				05D62CC7266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
+				AABFE14126839C7C00B6344C /* RemoteItemRepository.swift in Sources */,
 				AAD1ADF926618FB70035EB67 /* Item.swift in Sources */,
 				AA8A8949265D778D0005C3BC /* ItemsViewController.swift in Sources */,
 				AABFE13F2683758600B6344C /* StaticItemRepository.swift in Sources */,

--- a/GuildedRoseLLC/Items/Item.swift
+++ b/GuildedRoseLLC/Items/Item.swift
@@ -3,6 +3,11 @@ public struct Item {
     public init(name: String) {
         self.name = name
     }
+    
+    public init(json: [String: Any]) {
+        self.name = json["name"] as? String ?? "No name"
+    }
+    
     public let name: String
 }
 

--- a/GuildedRoseLLC/Items/ItemsViewController.swift
+++ b/GuildedRoseLLC/Items/ItemsViewController.swift
@@ -6,8 +6,8 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
     @IBOutlet public var itemCollectionView: UICollectionView!
     @IBOutlet public var noItemsLabel: UILabel!
     
-    var dataSource: ItemCollectionViewDataSource?
-    public var itemRepository: ItemRepository = StaticItemRepository()
+    public var dataSource: ItemCollectionViewDataSource?
+    public var itemRepository: ItemRepository = RemoteItemRepository()
 
     override public func viewDidLoad() {
         super.viewDidLoad()
@@ -22,9 +22,12 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
         var items: [Item] = []
         itemRepository.getItems() {(data: [Item]) in
             items = data
+            DispatchQueue.main.async {
+                self.configureDataSource(items: items)
+                self.toggleListDisplay(items: items)
+            }
         }
-        configureDataSource(items: items)
-        toggleListDisplay(items: items)
+
     }
     
     private func toggleListDisplay(items: [Item]) {
@@ -39,9 +42,10 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
     
     private func configureDataSource(items: [Item] = []) {
         dataSource = ItemCollectionViewDataSource()
+        dataSource?.show(items: items)
+        
         itemCollectionView.dataSource = dataSource
         itemCollectionView.delegate = self
         
-        dataSource?.show(items: items)
     }
 }

--- a/GuildedRoseLLC/Items/RemoteItemRepository.swift
+++ b/GuildedRoseLLC/Items/RemoteItemRepository.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+public class RemoteItemRepository: ItemRepository {
+    
+    public init() {}
+    
+    public func getItems(onSuccess: @escaping ([Item]) -> Void) {
+        var itemList: [Item] = []
+        
+        let url = URL(string: "https://safe-wave-09726.herokuapp.com/api/v1/items")
+        guard let requestURL = url else { fatalError("The internet is broken")}
+        
+        let request = URLRequest(url: requestURL)
+        
+        let task = URLSession.shared.dataTask(with: request) {data,response,error in
+            if error != nil {
+                return
+            } else {
+                if let data = data {
+                    let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]]
+                    if let json = json {
+                        itemList = json.map{
+                            Item(json: $0)
+                        }
+                        onSuccess(itemList)
+                    }
+                }
+            }
+        }
+        task.resume()
+    }
+}

--- a/GuildedRoseLLC/Items/RemoteItemRepository.swift
+++ b/GuildedRoseLLC/Items/RemoteItemRepository.swift
@@ -7,7 +7,7 @@ public class RemoteItemRepository: ItemRepository {
     public func getItems(onSuccess: @escaping ([Item]) -> Void) {
         var itemList: [Item] = []
         
-        let url = URL(string: "https://safe-wave-09726.herokuapp.com/api/v1/items")
+        let url = URL(string: "https://floating-spire-59497.herokuapp.com/api/v1/items")
         guard let requestURL = url else { fatalError("The internet is broken")}
         
         let request = URLRequest(url: requestURL)

--- a/GuildedRoseLLC/Items/StaticItemRepository.swift
+++ b/GuildedRoseLLC/Items/StaticItemRepository.swift
@@ -1,4 +1,3 @@
-
 public class StaticItemRepository : ItemRepository {
     
     public init() {}

--- a/GuildedRoseLLCSpec/Fakes/FakeItemRepository.swift
+++ b/GuildedRoseLLCSpec/Fakes/FakeItemRepository.swift
@@ -1,16 +1,14 @@
 import GuildedRoseLLC
 
-public class FakeItemRepository: ItemRepository {
+class FakeItemRepository: ItemRepository {
 
-    public init() {}
-    
     var itemsList: [Item] = []
     
-    public func getItems(onSuccess: @escaping ([Item]) -> Void) {
+    func getItems(onSuccess: @escaping ([Item]) -> Void) {
         onSuccess(itemsList)
     }
     
-    public func stub(items: [Item]) {
+    func stub(items: [Item]) {
       itemsList = items
     }
 }

--- a/GuildedRoseLLCSpec/Fakes/FakeItemRepositorySpec.swift
+++ b/GuildedRoseLLCSpec/Fakes/FakeItemRepositorySpec.swift
@@ -5,6 +5,7 @@ import Nimble
 class FakeItemRepositorySpec: QuickSpec {
     
     override func spec() {
+        
         describe("Getting the items") {
             it("calls the callback") {
                 var wasCallbackCalled = false

--- a/GuildedRoseLLCSpec/ItemRepositorySpec.swift
+++ b/GuildedRoseLLCSpec/ItemRepositorySpec.swift
@@ -10,6 +10,7 @@ class ItemRepositorySpec : QuickSpec {
             it("sets a list of items") {
                 var data: [Item] = []
                 let itemRepository = StaticItemRepository()
+                
                 itemRepository.getItems() {(items: [Item]) in
                     data = items
                 }

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -20,43 +20,40 @@ class ItemViewControllerSpec: QuickSpec {
             
             describe("viewDidLoad") {
                 it("creates a data source") {
+                    
                     controller.viewDidLoad()
                     
                     expect(controller.itemCollectionView.dataSource).notTo(beNil())
                 }
                 
                 it("creates a repository") {
+                    
                     controller.viewDidLoad()
                     
                     expect(controller.itemRepository).notTo(beNil())
                 }
                 
                 it("sets the data source to an empty list") {
+                    
                     controller.viewDidLoad()
                     
-                    let dataSource = controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource
-                    
-                    expect(dataSource?.items).to(equal([]))
+                    expect((controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource)?.items).to(equal([]))
                 }
             }
             
             describe("viewWillAppear") {
                 it("sets the data source to a static item list") {
-                    
                     let itemRepository = FakeItemRepository()
                     itemRepository.stub(items: Item.testData)
                     controller.itemRepository = itemRepository
                     
                     controller.viewDidLoad()
                     controller.viewWillAppear(true)
-
-                    let dataSource = controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource
                     
-                    expect(dataSource?.items).to(equal(Item.testData))
+                    expect((controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource)?.items).toEventually(equal(Item.testData))
                 }
                 
                 it("hides the item collection view when there are no items") {
-                    
                     let itemRepository = FakeItemRepository()
                     itemRepository.stub(items: [])
                     controller.itemRepository = itemRepository
@@ -64,11 +61,10 @@ class ItemViewControllerSpec: QuickSpec {
                     controller.viewDidLoad()
                     controller.viewWillAppear(true)
                     
-                    expect(controller.itemCollectionView.isHidden).to(beTrue())
+                    expect(controller.itemCollectionView.isHidden).toEventually(beTrue())
                 }
                 
                 it("shows the 'no items message' when there are no items") {
-                    
                     let itemRepository = FakeItemRepository()
                     itemRepository.stub(items: [])
                     controller.itemRepository = itemRepository
@@ -76,11 +72,10 @@ class ItemViewControllerSpec: QuickSpec {
                     controller.viewDidLoad()
                     controller.viewWillAppear(true)
                     
-                    expect(controller.noItemsLabel.isHidden).to(beFalse())
+                    expect(controller.noItemsLabel.isHidden).toEventually(beFalse())
                 }
                 
-                it("shows the item collection view when there are items") {
-                    
+                it("shows the item collection view when there is an item") {
                     let itemRepository = FakeItemRepository()
                     itemRepository.stub(items: [Item(name: "FooBar")])
                     controller.itemRepository = itemRepository
@@ -92,7 +87,6 @@ class ItemViewControllerSpec: QuickSpec {
                 }
                 
                 it("does not show the 'no items message' when there are items") {
-                    
                     let itemRepository = FakeItemRepository()
                     itemRepository.stub(items: [Item(name: "FooBar")])
                     controller.itemRepository = itemRepository
@@ -100,7 +94,7 @@ class ItemViewControllerSpec: QuickSpec {
                     controller.viewDidLoad()
                     controller.viewWillAppear(true)
                     
-                    expect(controller.noItemsLabel.isHidden).to(beTrue())
+                    expect(controller.noItemsLabel.isHidden).toEventually(beTrue())
                 }
             }
         }

--- a/ModelsSpec/ModelsSpec.swift
+++ b/ModelsSpec/ModelsSpec.swift
@@ -7,10 +7,16 @@ class ItemSpec: QuickSpec {
     override func spec() {
         
         describe("an Item") {
-            it("sets the name on instantiation") {
+            it("sets the name from a string") {
                 let brie = Item(name: "Brie")
                 
                 expect(brie.name).to(equal("Brie"))
+            }
+            
+            it("sets the name from json") {
+                let brie = Item(json: ["id": 4, "name": "Aged Brie", "sellIn": 7, "quality": 5])
+                
+                expect(brie.name).to(equal("Aged Brie"))
             }
         }
     }


### PR DESCRIPTION
## Summary
the `add-network-call` branch defines a RemoteItemRepository which makes a network call to the back end.

## Future Work
~~Change to use the staging API~~, implement suggested changes from add-fake-repository PR, update UI to match wireframes