### PR TITLE
removed hardcoded Items from Item struct

### DIFF
--- a/GuildedRoseLLC/Items/Item.swift
+++ b/GuildedRoseLLC/Items/Item.swift
@@ -16,15 +16,3 @@ extension Item:Equatable{
         return lhs.name == rhs.name
     }
 }
-
-public extension Item {
-    static var testData = [
-        Item(name: "Foo"),
-        Item(name: "Bar"),
-        Item(name: "FooBar"),
-        Item(name: "Lorem"),
-        Item(name: "Ipsum"),
-        Item(name: "VeniVidiVici"),
-    ]
-    static var singleTestItem = Item(name: "Foo")
-}

--- a/GuildedRoseLLC/Items/ItemCollectionViewDataSource.swift
+++ b/GuildedRoseLLC/Items/ItemCollectionViewDataSource.swift
@@ -4,7 +4,7 @@ public class ItemCollectionViewDataSource: NSObject, UICollectionViewDataSource 
     
     public var items: [Item] = []
 
-    public func show(items: [Item]) {
+    public func show(items: [Item] = []) {
         self.items = items
     }
     

--- a/GuildedRoseLLC/Items/StaticItemRepository.swift
+++ b/GuildedRoseLLC/Items/StaticItemRepository.swift
@@ -2,8 +2,18 @@ public class StaticItemRepository : ItemRepository {
     
     public init() {}
     
+    let testData = [
+        Item(name: "Foo"),
+        Item(name: "Bar"),
+        Item(name: "FooBar"),
+        Item(name: "Lorem"),
+        Item(name: "Ipsum"),
+        Item(name: "VeniVidiVici"),
+    ]
+    
     public func getItems(onSuccess: @escaping (_:[Item]) -> Void){
-        let items: [Item] = Item.testData
+
+        let items: [Item] = testData
         
         onSuccess(items)
     }

--- a/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
+++ b/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
@@ -14,10 +14,10 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
             return collectionView
         }
         
-        describe("the number of items") {
+        describe("building a datasource with a list of items") {
             it("has no items") {
                 let dataSource = ItemCollectionViewDataSource()
-                dataSource.show(items: [])
+                dataSource.show()
                 let collectionView = buildCollectionView()
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
                 
@@ -34,8 +34,16 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
             }
             
             it("has six items") {
+                let testData = [
+                    Item(name: "Foo"),
+                    Item(name: "Bar"),
+                    Item(name: "FooBar"),
+                    Item(name: "Lorem"),
+                    Item(name: "Ipsum"),
+                    Item(name: "VeniVidiVici"),
+                ]
                 let dataSource = ItemCollectionViewDataSource()
-                dataSource.show(items: Item.testData)
+                dataSource.show(items: testData)
                 let collectionView = buildCollectionView()
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
                 

--- a/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
+++ b/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
@@ -15,7 +15,7 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
         }
         
         describe("building a datasource with a list of items") {
-            it("has no items") {
+            it("has no items by default") {
                 let dataSource = ItemCollectionViewDataSource()
                 dataSource.show()
                 let collectionView = buildCollectionView()

--- a/GuildedRoseLLCSpec/ItemRepositorySpec.swift
+++ b/GuildedRoseLLCSpec/ItemRepositorySpec.swift
@@ -8,6 +8,14 @@ class ItemRepositorySpec : QuickSpec {
         
         describe("getItems"){
             it("sets a list of items") {
+                let expectedTestData = [
+                    Item(name: "Foo"),
+                    Item(name: "Bar"),
+                    Item(name: "FooBar"),
+                    Item(name: "Lorem"),
+                    Item(name: "Ipsum"),
+                    Item(name: "VeniVidiVici"),
+                ]
                 var data: [Item] = []
                 let itemRepository = StaticItemRepository()
                 
@@ -15,7 +23,7 @@ class ItemRepositorySpec : QuickSpec {
                     data = items
                 }
                 
-                expect(data).to(equal(Item.testData))
+                expect(data).to(equal(expectedTestData))
             }
         }
     }

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -36,7 +36,7 @@ class ItemViewControllerSpec: QuickSpec {
                 it("sets the data source to an empty list") {
                     
                     controller.viewDidLoad()
-                    // Discuss this with @eric re: should we have declaration of dataSource inside the expect or not? 
+                    // The datasource is created inside the expect block to mirror line 61 which has to be created inside expect for async behavior. 
                     expect((controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource)?.items).to(equal([]))
                 }
             }

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -36,21 +36,29 @@ class ItemViewControllerSpec: QuickSpec {
                 it("sets the data source to an empty list") {
                     
                     controller.viewDidLoad()
-                    
+                    // Discuss this with @eric re: should we have declaration of dataSource inside the expect or not? 
                     expect((controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource)?.items).to(equal([]))
                 }
             }
             
             describe("viewWillAppear") {
                 it("sets the data source to a static item list") {
+                    let expectedTestData = [
+                        Item(name: "Foo"),
+                        Item(name: "Bar"),
+                        Item(name: "FooBar"),
+                        Item(name: "Lorem"),
+                        Item(name: "Ipsum"),
+                        Item(name: "VeniVidiVici"),
+                    ]
                     let itemRepository = FakeItemRepository()
-                    itemRepository.stub(items: Item.testData)
+                    itemRepository.stub(items: expectedTestData)
                     controller.itemRepository = itemRepository
                     
                     controller.viewDidLoad()
                     controller.viewWillAppear(true)
                     
-                    expect((controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource)?.items).toEventually(equal(Item.testData))
+                    expect((controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource)?.items).toEventually(equal(expectedTestData))
                 }
                 
                 it("hides the item collection view when there are no items") {


### PR DESCRIPTION
## Notes
CI passes tests on both Malisa's and Ethan's local devices.

## Summary
The `remove-test-items` branch removes test Items from the Item struct to separate test code from production code

## Future Work:
- Clean up RemoteRepository to allow for passing in of URL, more robust testing