### PR TITLE
Add detail show page

### DIFF
--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05B2888B2695FFB7007B6727 /* DetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2888A2695FFB7007B6727 /* DetailsViewController.swift */; };
+		05B2888D26960768007B6727 /* DetailsViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2888C26960768007B6727 /* DetailsViewControllerSpec.swift */; };
 		05B4B6DA268272C100D0EFA6 /* ItemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B4B6D9268272C100D0EFA6 /* ItemRepository.swift */; };
 		05B4B6DC2682748200D0EFA6 /* ItemRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B4B6DB2682748200D0EFA6 /* ItemRepositorySpec.swift */; };
 		05B4B6DF2683782600D0EFA6 /* FakeItemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B4B6DE2683782600D0EFA6 /* FakeItemRepository.swift */; };
@@ -51,6 +53,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		05B2888A2695FFB7007B6727 /* DetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsViewController.swift; sourceTree = "<group>"; };
+		05B2888C26960768007B6727 /* DetailsViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsViewControllerSpec.swift; sourceTree = "<group>"; };
 		05B4B6D9268272C100D0EFA6 /* ItemRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRepository.swift; sourceTree = "<group>"; };
 		05B4B6DB2682748200D0EFA6 /* ItemRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRepositorySpec.swift; sourceTree = "<group>"; };
 		05B4B6DE2683782600D0EFA6 /* FakeItemRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeItemRepository.swift; sourceTree = "<group>"; };
@@ -108,6 +112,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		05B288892695FF91007B6727 /* Details */ = {
+			isa = PBXGroup;
+			children = (
+				05B2888A2695FFB7007B6727 /* DetailsViewController.swift */,
+			);
+			path = Details;
+			sourceTree = "<group>";
+		};
 		05B4B6DD2683780C00D0EFA6 /* Fakes */ = {
 			isa = PBXGroup;
 			children = (
@@ -141,6 +153,7 @@
 		AA8A8943265D778D0005C3BC /* GuildedRoseLLC */ = {
 			isa = PBXGroup;
 			children = (
+				05B288892695FF91007B6727 /* Details */,
 				AABFE13C268373D100B6344C /* Items */,
 				AABFE13D268373F600B6344C /* Supporting Files */,
 				AA8A8952265D778F0005C3BC /* Info.plist */,
@@ -160,6 +173,7 @@
 				AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */,
 				05B4B6DB2682748200D0EFA6 /* ItemRepositorySpec.swift */,
 				05DEADDE268D133F0092B635 /* ItemParserSpec.swift */,
+				05B2888C26960768007B6727 /* DetailsViewControllerSpec.swift */,
 			);
 			path = GuildedRoseLLCSpec;
 			sourceTree = "<group>";
@@ -351,6 +365,7 @@
 				05D62CCC266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */,
 				05D62CC7266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */,
 				AABFE14126839C7C00B6344C /* RemoteItemRepository.swift in Sources */,
+				05B2888B2695FFB7007B6727 /* DetailsViewController.swift in Sources */,
 				AAD1ADF926618FB70035EB67 /* Item.swift in Sources */,
 				AA8A8949265D778D0005C3BC /* ItemsViewController.swift in Sources */,
 				AACA59112694A6540057480C /* ItemParser.swift in Sources */,
@@ -371,6 +386,7 @@
 				05B4B6E12683783800D0EFA6 /* FakeItemRepositorySpec.swift in Sources */,
 				AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */,
 				05DEADDF268D133F0092B635 /* ItemParserSpec.swift in Sources */,
+				05B2888D26960768007B6727 /* DetailsViewControllerSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		05D62CC7266E9E4600675D09 /* ItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */; };
 		05D62CCC266E9FD000675D09 /* ItemCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */; };
 		05DEADDF268D133F0092B635 /* ItemParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DEADDE268D133F0092B635 /* ItemParserSpec.swift */; };
+		AA321FFC269DE5F300D25FF5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA321FFB269DE5F300D25FF5 /* Constants.swift */; };
 		AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */; };
 		AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8944265D778D0005C3BC /* AppDelegate.swift */; };
 		AA8A8947265D778D0005C3BC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8946265D778D0005C3BC /* SceneDelegate.swift */; };
@@ -62,6 +63,7 @@
 		05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewCell.swift; sourceTree = "<group>"; };
 		05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		05DEADDE268D133F0092B635 /* ItemParserSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemParserSpec.swift; sourceTree = "<group>"; };
+		AA321FFB269DE5F300D25FF5 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCollectionViewDataSourceSpec.swift; sourceTree = "<group>"; };
 		AA8A8941265D778D0005C3BC /* GuildedRoseLLC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GuildedRoseLLC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA8A8944265D778D0005C3BC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				AA8A894D265D778F0005C3BC /* Assets.xcassets */,
 				AA8A894F265D778F0005C3BC /* LaunchScreen.storyboard */,
 				AA8A894A265D778D0005C3BC /* Main.storyboard */,
+				AA321FFB269DE5F300D25FF5 /* Constants.swift */,
 			);
 			path = GuildedRoseLLC;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */,
 				AA8A8947265D778D0005C3BC /* SceneDelegate.swift in Sources */,
 				05B4B6DA268272C100D0EFA6 /* ItemRepository.swift in Sources */,
+				AA321FFC269DE5F300D25FF5 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GuildedRoseLLC/Base.lproj/Main.storyboard
+++ b/GuildedRoseLLC/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pXK-eT-BJZ">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="31" translatesAutoresizingMaskIntoConstraints="NO" id="PSS-sa-E6E">
-                                <rect key="frame" x="30" y="119" width="354" height="142.5"/>
+                                <rect key="frame" x="30" y="163" width="354" height="142.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to the Guilded Rose LLC!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nmN-JN-H6b">
                                         <rect key="frame" x="0.0" y="0.0" width="354" height="35"/>
@@ -50,7 +50,7 @@
                                 </subviews>
                             </stackView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Fzc-Sc-AaE">
-                                <rect key="frame" x="30" y="270" width="364" height="542"/>
+                                <rect key="frame" x="30" y="314" width="364" height="498"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="layoutMargins" id="EIA-g4-jzH">
                                     <size key="itemSize" width="330" height="64"/>
@@ -72,6 +72,14 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BeD-hX-Ew5">
+                                                    <rect key="frame" x="274" y="15" width="30" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <state key="normal" title="&gt;"/>
+                                                    <connections>
+                                                        <segue destination="AcX-cJ-yCo" kind="show" identifier="detailsPageSegue" id="aSm-on-qDz"/>
+                                                    </connections>
+                                                </button>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="JSt-SO-6cq" firstAttribute="centerX" secondItem="Btb-qB-ZXS" secondAttribute="centerX" id="Is1-0h-uMl"/>
@@ -85,6 +93,7 @@
                                         <connections>
                                             <outlet property="itemCell" destination="Btb-qB-ZXS" id="4Xb-KO-8JX"/>
                                             <outlet property="itemCellLabel" destination="JSt-SO-6cq" id="RhG-t1-f6d"/>
+                                            <outlet property="itemDetailButton" destination="BeD-hX-Ew5" id="E4z-F4-TRL"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -103,6 +112,7 @@
                             <constraint firstItem="PSS-sa-E6E" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="iAP-j4-oJv"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="fHK-Pg-8aK"/>
                     <connections>
                         <outlet property="greeting" destination="nmN-JN-H6b" id="cpL-zQ-T5I"/>
                         <outlet property="itemCollectionView" destination="Fzc-Sc-AaE" id="wOh-Op-yH8"/>
@@ -111,7 +121,56 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="31.199999999999999" y="74.212893553223395"/>
+            <point key="canvasLocation" x="57.971014492753625" y="64.955357142857139"/>
+        </scene>
+        <!--Detail View Controller-->
+        <scene sceneID="MqL-PD-8Tc">
+            <objects>
+                <viewController id="AcX-cJ-yCo" customClass="DetailViewController" customModule="GuildedRoseLLC" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ca1-4m-diM">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fa3-fn-fhC">
+                                <rect key="frame" x="159" y="184" width="39" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="3Yf-Av-dYO"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Fa3-fn-fhC" firstAttribute="top" secondItem="3Yf-Av-dYO" secondAttribute="top" constant="96" id="JRx-kB-aFp"/>
+                            <constraint firstItem="Fa3-fn-fhC" firstAttribute="leading" secondItem="3Yf-Av-dYO" secondAttribute="leading" constant="159" id="RIj-bP-DfT"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="4hj-Qn-nVG"/>
+                    <connections>
+                        <outlet property="ItemName" destination="Fa3-fn-fhC" id="YmS-vr-B79"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="l86-jE-IM6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="891.304347826087" y="72.991071428571431"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="i0u-kK-Ybg">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pXK-eT-BJZ" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Nzp-bW-qHL">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="Att-3l-NdZ"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="R0l-eb-HiR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-852.17391304347836" y="64.955357142857139"/>
         </scene>
     </scenes>
     <resources>

--- a/GuildedRoseLLC/Base.lproj/Main.storyboard
+++ b/GuildedRoseLLC/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--Items View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="GreetingViewControllerID" id="BYZ-38-t0r" customClass="ItemsViewController" customModule="GuildedRoseLLC" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ItemsViewController" id="BYZ-38-t0r" customClass="ItemsViewController" customModule="GuildedRoseLLC" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -77,7 +77,7 @@
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="&gt;"/>
                                                     <connections>
-                                                        <segue destination="AcX-cJ-yCo" kind="show" identifier="detailsPageSegue" id="aSm-on-qDz"/>
+                                                        <segue destination="AcX-cJ-yCo" kind="show" identifier="DetailsPageSegue" id="aSm-on-qDz"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
@@ -126,7 +126,7 @@
         <!--Detail View Controller-->
         <scene sceneID="MqL-PD-8Tc">
             <objects>
-                <viewController id="AcX-cJ-yCo" customClass="DetailViewController" customModule="GuildedRoseLLC" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DetailViewController" id="AcX-cJ-yCo" customClass="DetailViewController" customModule="GuildedRoseLLC" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ca1-4m-diM">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/GuildedRoseLLC/Constants.swift
+++ b/GuildedRoseLLC/Constants.swift
@@ -1,0 +1,3 @@
+public enum StoryboardIDs {
+    public static let SEGUE__INDEX_TO_DETAIL = "DetailsPageSegue"
+}

--- a/GuildedRoseLLC/Constants.swift
+++ b/GuildedRoseLLC/Constants.swift
@@ -1,3 +1,3 @@
-public enum StoryboardIDs {
-    public static let SEGUE__INDEX_TO_DETAIL = "DetailsPageSegue"
+public enum ItemSegue {
+    public static let showDetails = "DetailsPageSegue"
 }

--- a/GuildedRoseLLC/Details/DetailsViewController.swift
+++ b/GuildedRoseLLC/Details/DetailsViewController.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+public class DetailViewController: UIViewController {
+  
+    
+    @IBOutlet public var itemName: UILabel!
+    public var setItem: (() -> Item)?
+    public var item: Item?
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        if let thisItem = setItem? () {
+            self.item = thisItem
+        }
+        itemName.text = item?.name
+    }
+}

--- a/GuildedRoseLLC/Details/DetailsViewController.swift
+++ b/GuildedRoseLLC/Details/DetailsViewController.swift
@@ -11,6 +11,7 @@ public class DetailViewController: UIViewController {
         if let thisItem = setItem? () {
             self.item = thisItem
         }
+        
         itemName.text = item?.name
     }
 }

--- a/GuildedRoseLLC/Details/DetailsViewController.swift
+++ b/GuildedRoseLLC/Details/DetailsViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 
 public class DetailViewController: UIViewController {
   
-    
     @IBOutlet public var itemName: UILabel!
     public var setItem: (() -> Item)?
     public var item: Item?

--- a/GuildedRoseLLC/Items/ItemCollectionViewCell.swift
+++ b/GuildedRoseLLC/Items/ItemCollectionViewCell.swift
@@ -4,4 +4,5 @@ public class ItemCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet var itemCell: UIView!
     @IBOutlet var itemCellLabel: UILabel!
+    @IBOutlet var itemDetailButton: UIButton!
 }

--- a/GuildedRoseLLC/Items/ItemCollectionViewDataSource.swift
+++ b/GuildedRoseLLC/Items/ItemCollectionViewDataSource.swift
@@ -16,6 +16,7 @@ public class ItemCollectionViewDataSource: NSObject, UICollectionViewDataSource 
         
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath) as! ItemCollectionViewCell
         cell.itemCellLabel.text = items[indexPath.row].name
+        cell.itemDetailButton.tag = indexPath.row
 
         return cell
     }

--- a/GuildedRoseLLC/Items/ItemsViewController.swift
+++ b/GuildedRoseLLC/Items/ItemsViewController.swift
@@ -25,7 +25,6 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
                 self.toggleListDisplay(items: items)
             }
         }
-
     }
     
     private func toggleListDisplay(items: [Item]) {
@@ -44,17 +43,18 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
         
         itemCollectionView.dataSource = dataSource
         itemCollectionView.delegate = self
-        
     }
     
     public override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.destination is DetailViewController && sender is UIButton {
+        if segue.identifier == "DetailsPageSegue" {
             let destination = segue.destination as! DetailViewController
             let button = sender as! UIButton
             let item: Item = (self.dataSource?.items[button.tag])!
-            
             destination.setItem = {
-                () in return item
+                () in
+                print(item)
+                return item
+             
             }
         }
     }

--- a/GuildedRoseLLC/Items/ItemsViewController.swift
+++ b/GuildedRoseLLC/Items/ItemsViewController.swift
@@ -12,9 +12,6 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
     override public func viewDidLoad() {
         super.viewDidLoad()
         configureDataSource()
-        
-        greeting.accessibilityIdentifier = "Greeting"
-        itemCollectionView.accessibilityIdentifier = "itemCollectionView"
     }
     
     override public func viewWillAppear(_ animated: Bool) {
@@ -46,13 +43,12 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
     }
     
     public override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "DetailsPageSegue" {
+        if segue.identifier == StoryboardIDs.SEGUE__INDEX_TO_DETAIL {
             let destination = segue.destination as! DetailViewController
             let button = sender as! UIButton
             let item: Item = (self.dataSource?.items[button.tag])!
             destination.setItem = {
                 () in
-                print(item)
                 return item
              
             }

--- a/GuildedRoseLLC/Items/ItemsViewController.swift
+++ b/GuildedRoseLLC/Items/ItemsViewController.swift
@@ -46,4 +46,16 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
         itemCollectionView.delegate = self
         
     }
+    
+    public override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.destination is DetailViewController && sender is UIButton {
+            let destination = segue.destination as! DetailViewController
+            let button = sender as! UIButton
+            let item: Item = (self.dataSource?.items[button.tag])!
+            
+            destination.setItem = {
+                () in return item
+            }
+        }
+    }
 }

--- a/GuildedRoseLLC/Items/ItemsViewController.swift
+++ b/GuildedRoseLLC/Items/ItemsViewController.swift
@@ -43,7 +43,7 @@ public class ItemsViewController: UIViewController, UICollectionViewDelegate {
     }
     
     public override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == StoryboardIDs.SEGUE__INDEX_TO_DETAIL {
+        if segue.identifier == ItemSegue.showDetails {
             let destination = segue.destination as! DetailViewController
             let button = sender as! UIButton
             let item: Item = (self.dataSource?.items[button.tag])!

--- a/GuildedRoseLLCSpec/DetailsViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/DetailsViewControllerSpec.swift
@@ -1,0 +1,23 @@
+import Quick
+import Nimble
+import GuildedRoseLLC
+import XCTest
+
+class DetailsViewControllerSpec: QuickSpec {
+    override func spec() {
+        
+        describe("View did load"){
+            it("sets the item using the setItem closure"){
+                let detailsController = DetailViewController()
+                detailsController.setItem = {
+                    () in return Item(name: "FooBar")
+                }
+                detailsController.itemName = UILabel()
+                
+                detailsController.viewDidLoad()
+                
+                expect(detailsController.item?.name).to(equal("FooBar"))
+            }
+        }
+    }
+}

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -125,7 +125,7 @@ class ItemViewControllerSpec: QuickSpec {
             
             describe("prepare for segue") {
                 it("sets the item when 'DetailsPageSegue' is called") {
-                    let segue = UIStoryboardSegue(identifier: StoryboardIDs.INDEXTODETAILSEGUEID, source: itemsController, destination: detailsController)
+                    let segue = UIStoryboardSegue(identifier: ItemSegue.INDEXTODETAILSEGUEID, source: itemsController, destination: detailsController)
                     
                     itemsController.prepare(for: segue, sender: button)
                     detailsController.viewDidLoad()

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -125,7 +125,7 @@ class ItemViewControllerSpec: QuickSpec {
             
             describe("prepare for segue") {
                 it("sets the item when 'DetailsPageSegue' is called") {
-                    let segue = UIStoryboardSegue(identifier: "DetailsPageSegue", source: itemsController, destination: detailsController)
+                    let segue = UIStoryboardSegue(identifier: StoryboardIDs.INDEXTODETAILSEGUEID, source: itemsController, destination: detailsController)
                     
                     itemsController.prepare(for: segue, sender: button)
                     detailsController.viewDidLoad()

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -7,7 +7,7 @@ class ItemViewControllerSpec: QuickSpec {
     
     override func spec() {
         
-        describe("Loading the view") {
+        context("Loading the view") {
             var controller: GuildedRoseLLC.ItemsViewController!
             
             beforeEach {
@@ -20,23 +20,20 @@ class ItemViewControllerSpec: QuickSpec {
             
             describe("viewDidLoad") {
                 it("creates a data source") {
-                    
                     controller.viewDidLoad()
                     
                     expect(controller.itemCollectionView.dataSource).notTo(beNil())
                 }
                 
                 it("creates a repository") {
-                    
                     controller.viewDidLoad()
                     
                     expect(controller.itemRepository).notTo(beNil())
                 }
                 
                 it("sets the data source to an empty list") {
-                    
                     controller.viewDidLoad()
-                    // The datasource is created inside the expect block to mirror line 61 which has to be created inside expect for async behavior. 
+
                     expect((controller.itemCollectionView.dataSource as? ItemCollectionViewDataSource)?.items).to(equal([]))
                 }
             }
@@ -103,6 +100,46 @@ class ItemViewControllerSpec: QuickSpec {
                     controller.viewWillAppear(true)
                     
                     expect(controller.noItemsLabel.isHidden).toEventually(beTrue())
+                }
+            }
+        }
+        
+        context("transitioning to another view") {
+            var itemsController: GuildedRoseLLC.ItemsViewController!
+            var detailsController: GuildedRoseLLC.DetailViewController!
+            var button:UIButton!
+            let item = Item(name: "foo")
+            
+            beforeEach {
+                itemsController = ItemsViewController()
+                let dataSource = GuildedRoseLLC.ItemCollectionViewDataSource()
+                dataSource.show(items: [item])
+
+                itemsController.dataSource = dataSource
+         
+                detailsController = DetailViewController()
+                detailsController.itemName = UILabel()
+                button = UIButton()
+                button.tag = 0
+            }
+            
+            describe("prepare for segue") {
+                it("sets the item when 'DetailsPageSegue' is called") {
+                    let segue = UIStoryboardSegue(identifier: "DetailsPageSegue", source: itemsController, destination: detailsController)
+                    
+                    itemsController.prepare(for: segue, sender: button)
+                    detailsController.viewDidLoad()
+                  
+                    expect(detailsController.item).to(equal(item))
+                }
+                
+                it("doesn't set the item when 'ArbitrarySegue' is called") {
+                    let segue = UIStoryboardSegue(identifier: "ArbitrarySegue", source: itemsController, destination: detailsController)
+                    
+                    itemsController.prepare(for: segue, sender: button)
+                    detailsController.viewDidLoad()
+                  
+                    expect(detailsController.item).to(beNil())
                 }
             }
         }


### PR DESCRIPTION
## Summary

The `add-show-page` branch gives the user the ability to click on any item in the Guilded Rose and view the item's detail page. 

Figure 1. Video of transition to item show page. 

https://user-images.githubusercontent.com/43938783/124796569-ee95c780-df16-11eb-8a7b-0d36cf3151c8.mov

Future work:
- Add the rest of the item details (sellin, quality).
- Clean up the UI.

