### PR TITLE
Builder pattern

### DIFF
--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		05B2888B2695FFB7007B6727 /* DetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2888A2695FFB7007B6727 /* DetailsViewController.swift */; };
 		05B2888D26960768007B6727 /* DetailsViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2888C26960768007B6727 /* DetailsViewControllerSpec.swift */; };
-		05B2889026A0C13B007B6727 /* ItemTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2888F26A0C13B007B6727 /* ItemTestData.swift */; };
 		05B4B6DA268272C100D0EFA6 /* ItemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B4B6D9268272C100D0EFA6 /* ItemRepository.swift */; };
 		05B4B6DC2682748200D0EFA6 /* ItemRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B4B6DB2682748200D0EFA6 /* ItemRepositorySpec.swift */; };
 		05B4B6DF2683782600D0EFA6 /* FakeItemRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B4B6DE2683782600D0EFA6 /* FakeItemRepository.swift */; };
@@ -19,6 +18,7 @@
 		05DEADDF268D133F0092B635 /* ItemParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DEADDE268D133F0092B635 /* ItemParserSpec.swift */; };
 		AA321FFC269DE5F300D25FF5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA321FFB269DE5F300D25FF5 /* Constants.swift */; };
 		AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA547F69266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift */; };
+		AA6406FD26BBBA1D006F363B /* ItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2888F26A0C13B007B6727 /* ItemBuilder.swift */; };
 		AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8944265D778D0005C3BC /* AppDelegate.swift */; };
 		AA8A8947265D778D0005C3BC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8946265D778D0005C3BC /* SceneDelegate.swift */; };
 		AA8A8949265D778D0005C3BC /* ItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8A8948265D778D0005C3BC /* ItemsViewController.swift */; };
@@ -57,7 +57,7 @@
 /* Begin PBXFileReference section */
 		05B2888A2695FFB7007B6727 /* DetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsViewController.swift; sourceTree = "<group>"; };
 		05B2888C26960768007B6727 /* DetailsViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsViewControllerSpec.swift; sourceTree = "<group>"; };
-		05B2888F26A0C13B007B6727 /* ItemTestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemTestData.swift; sourceTree = "<group>"; };
+		05B2888F26A0C13B007B6727 /* ItemBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemBuilder.swift; sourceTree = "<group>"; };
 		05B4B6D9268272C100D0EFA6 /* ItemRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRepository.swift; sourceTree = "<group>"; };
 		05B4B6DB2682748200D0EFA6 /* ItemRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRepositorySpec.swift; sourceTree = "<group>"; };
 		05B4B6DE2683782600D0EFA6 /* FakeItemRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeItemRepository.swift; sourceTree = "<group>"; };
@@ -124,14 +124,6 @@
 			path = Details;
 			sourceTree = "<group>";
 		};
-		05B2888E26A0C129007B6727 /* TestData */ = {
-			isa = PBXGroup;
-			children = (
-				05B2888F26A0C13B007B6727 /* ItemTestData.swift */,
-			);
-			path = TestData;
-			sourceTree = "<group>";
-		};
 		05B4B6DD2683780C00D0EFA6 /* Fakes */ = {
 			isa = PBXGroup;
 			children = (
@@ -180,7 +172,6 @@
 		AA8A895A265D77900005C3BC /* GuildedRoseLLCSpec */ = {
 			isa = PBXGroup;
 			children = (
-				05B2888E26A0C129007B6727 /* TestData */,
 				05B4B6DD2683780C00D0EFA6 /* Fakes */,
 				AA8A895B265D77900005C3BC /* ItemViewControllerSpec.swift */,
 				AA8A895D265D77900005C3BC /* Info.plist */,
@@ -211,6 +202,7 @@
 		AABFE13C268373D100B6344C /* Items */ = {
 			isa = PBXGroup;
 			children = (
+				05B2888F26A0C13B007B6727 /* ItemBuilder.swift */,
 				AAD1ADF826618FB70035EB67 /* Item.swift */,
 				05D62CC6266E9E4600675D09 /* ItemCollectionViewCell.swift */,
 				05D62CCB266E9FD000675D09 /* ItemCollectionViewDataSource.swift */,
@@ -382,6 +374,7 @@
 				05B2888B2695FFB7007B6727 /* DetailsViewController.swift in Sources */,
 				AAD1ADF926618FB70035EB67 /* Item.swift in Sources */,
 				AA8A8949265D778D0005C3BC /* ItemsViewController.swift in Sources */,
+				AA6406FD26BBBA1D006F363B /* ItemBuilder.swift in Sources */,
 				AACA59112694A6540057480C /* ItemParser.swift in Sources */,
 				AABFE13F2683758600B6344C /* StaticItemRepository.swift in Sources */,
 				AA8A8945265D778D0005C3BC /* AppDelegate.swift in Sources */,
@@ -401,7 +394,6 @@
 				05B4B6E12683783800D0EFA6 /* FakeItemRepositorySpec.swift in Sources */,
 				AA547F6A266FD5E600FE325F /* ItemCollectionViewDataSourceSpec.swift in Sources */,
 				05DEADDF268D133F0092B635 /* ItemParserSpec.swift in Sources */,
-				05B2889026A0C13B007B6727 /* ItemTestData.swift in Sources */,
 				05B2888D26960768007B6727 /* DetailsViewControllerSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GuildedRoseLLC.xcodeproj/project.pbxproj
+++ b/GuildedRoseLLC.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		AAD1ADF526618F350035EB67 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = AAD1ADF426618F350035EB67 /* Quick */; };
 		AAD1ADF726618F390035EB67 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = AAD1ADF626618F390035EB67 /* Nimble */; };
 		AAD1ADF926618FB70035EB67 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1ADF826618FB70035EB67 /* Item.swift */; };
+		AAEF401026C2EC1E00B89D16 /* ItemBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEF400F26C2EC1E00B89D16 /* ItemBuilderSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,6 +86,7 @@
 		AABFE14026839C7C00B6344C /* RemoteItemRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteItemRepository.swift; sourceTree = "<group>"; };
 		AACA59102694A6540057480C /* ItemParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemParser.swift; sourceTree = "<group>"; };
 		AAD1ADF826618FB70035EB67 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		AAEF400F26C2EC1E00B89D16 /* ItemBuilderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemBuilderSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +181,7 @@
 				05B4B6DB2682748200D0EFA6 /* ItemRepositorySpec.swift */,
 				05DEADDE268D133F0092B635 /* ItemParserSpec.swift */,
 				05B2888C26960768007B6727 /* DetailsViewControllerSpec.swift */,
+				AAEF400F26C2EC1E00B89D16 /* ItemBuilderSpec.swift */,
 			);
 			path = GuildedRoseLLCSpec;
 			sourceTree = "<group>";
@@ -389,6 +392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA8A895C265D77900005C3BC /* ItemViewControllerSpec.swift in Sources */,
+				AAEF401026C2EC1E00B89D16 /* ItemBuilderSpec.swift in Sources */,
 				05B4B6DF2683782600D0EFA6 /* FakeItemRepository.swift in Sources */,
 				05B4B6DC2682748200D0EFA6 /* ItemRepositorySpec.swift in Sources */,
 				05B4B6E12683783800D0EFA6 /* FakeItemRepositorySpec.swift in Sources */,

--- a/GuildedRoseLLC/Items/ItemBuilder.swift
+++ b/GuildedRoseLLC/Items/ItemBuilder.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 public class ItemBuilder {
     public init() {}
     

--- a/GuildedRoseLLC/Items/ItemBuilder.swift
+++ b/GuildedRoseLLC/Items/ItemBuilder.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+public class ItemBuilder {
+    public static func build(name: String) -> Item {
+        return Item(name: name, sellIn: 1, quality: 2)
+    }
+}

--- a/GuildedRoseLLC/Items/ItemBuilder.swift
+++ b/GuildedRoseLLC/Items/ItemBuilder.swift
@@ -1,11 +1,28 @@
 import UIKit
 
 public class ItemBuilder {
-    public static func build(name: String) -> Item {
-        return Item(name: name, sellIn: 1, quality: 2)
+    public init() {}
+    
+    var name: String = ""
+    var sellIn: Int = 0
+    var quality: Int = 0
+
+    public func set(name: String) -> ItemBuilder {
+        self.name = name
+        return self
     }
     
-    public static func build(name: String, sellIn: Int, quality: Int) -> Item {
-        return Item(name: name, sellIn: sellIn, quality: quality)
+    public func set(sellIn: Int) -> ItemBuilder {
+        self.sellIn = sellIn
+        return self
+    }
+    
+    public func set(quality: Int) -> ItemBuilder {
+        self.quality = quality
+        return self
+    }
+    
+    public func build() -> Item {
+        return Item(name: self.name, sellIn: self.sellIn, quality: self.quality)
     }
 }

--- a/GuildedRoseLLC/Items/ItemBuilder.swift
+++ b/GuildedRoseLLC/Items/ItemBuilder.swift
@@ -4,4 +4,8 @@ public class ItemBuilder {
     public static func build(name: String) -> Item {
         return Item(name: name, sellIn: 1, quality: 2)
     }
+    
+    public static func build(name: String, sellIn: Int, quality: Int) -> Item {
+        return Item(name: name, sellIn: sellIn, quality: quality)
+    }
 }

--- a/GuildedRoseLLC/Items/StaticItemRepository.swift
+++ b/GuildedRoseLLC/Items/StaticItemRepository.swift
@@ -3,12 +3,12 @@ public class StaticItemRepository : ItemRepository {
     public init() {}
     
     let testData = [
-        Item(name: "Foo", sellIn: 5, quality: 7),
-        Item(name: "Bar", sellIn: 5, quality: 7),
-        Item(name: "FooBar", sellIn: 5, quality: 7),
-        Item(name: "Lorem", sellIn: 5, quality: 7),
-        Item(name: "Ipsum", sellIn: 5, quality: 7),
-        Item(name: "VeniVidiVici", sellIn: 5, quality: 7)
+        ItemBuilder.build(name: "Foo", sellIn: 5, quality: 7),
+        ItemBuilder.build(name: "Bar", sellIn: 5, quality: 7),
+        ItemBuilder.build(name: "FooBar", sellIn: 5, quality: 7),
+        ItemBuilder.build(name: "Lorem", sellIn: 5, quality: 7),
+        ItemBuilder.build(name: "Ipsum", sellIn: 5, quality: 7),
+        ItemBuilder.build(name: "VeniVidiVici", sellIn: 5, quality: 7)
     ]
     
     public func getItems(onSuccess: @escaping (_:[Item]) -> Void){

--- a/GuildedRoseLLC/Items/StaticItemRepository.swift
+++ b/GuildedRoseLLC/Items/StaticItemRepository.swift
@@ -3,12 +3,41 @@ public class StaticItemRepository : ItemRepository {
     public init() {}
     
     let testData = [
-        ItemBuilder.build(name: "Foo", sellIn: 5, quality: 7),
-        ItemBuilder.build(name: "Bar", sellIn: 5, quality: 7),
-        ItemBuilder.build(name: "FooBar", sellIn: 5, quality: 7),
-        ItemBuilder.build(name: "Lorem", sellIn: 5, quality: 7),
-        ItemBuilder.build(name: "Ipsum", sellIn: 5, quality: 7),
-        ItemBuilder.build(name: "VeniVidiVici", sellIn: 5, quality: 7)
+        ItemBuilder()
+            .set(name: "Foo")
+            .set(sellIn: 5)
+            .set(quality: 7)
+            .build(),
+        
+        ItemBuilder()
+            .set(name: "Bar")
+            .set(sellIn: 5)
+            .set(quality: 7)
+            .build(),
+        
+        ItemBuilder()
+            .set(name: "FooBar")
+            .set(sellIn: 5)
+            .set(quality: 7)
+            .build(),
+        
+        ItemBuilder()
+            .set(name: "Lorem")
+            .set(sellIn: 5)
+            .set(quality: 7)
+            .build(),
+        
+        ItemBuilder()
+            .set(name: "Ipsum")
+            .set(sellIn: 5)
+            .set(quality: 7)
+            .build(),
+        
+        ItemBuilder()
+            .set(name: "VeniVidiVici")
+            .set(sellIn: 5)
+            .set(quality: 7)
+            .build(),
     ]
     
     public func getItems(onSuccess: @escaping (_:[Item]) -> Void){

--- a/GuildedRoseLLCSpec/DetailsViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/DetailsViewControllerSpec.swift
@@ -14,7 +14,9 @@ class DetailsViewControllerSpec: QuickSpec {
                 detailsController.sellInLabel = UILabel()
                 
                 detailsController.setItem = {() in
-                    return ItemBuilder.build(name: "FooBar")
+                    return ItemBuilder()
+                        .set(name: "FooBar")
+                        .build()
                 }
                 
                 
@@ -30,9 +32,11 @@ class DetailsViewControllerSpec: QuickSpec {
                 detailsController.sellInLabel = UILabel()
                 
                 detailsController.setItem = {() in
-                    var item = ItemBuilder.build(name: "FooBar")
-                    item.quality = 5
-                    item.sellIn = 12
+                    let item = ItemBuilder()
+                        .set(name: "FooBar")
+                        .set(quality: 5)
+                        .set(sellIn: 12)
+                        .build()
                     return item
                 }
 
@@ -51,9 +55,11 @@ class DetailsViewControllerSpec: QuickSpec {
                 detailsController.sellInLabel = UILabel()
                 
                 detailsController.setItem = {() in
-                    var item = ItemBuilder.build(name: "FooBar")
-                    item.quality = 5
-                    item.sellIn = 12
+                    let item = ItemBuilder()
+                        .set(name: "FooBar")
+                        .set(quality: 5)
+                        .set(sellIn: 12)
+                        .build()
                     return item
                 }
                 

--- a/GuildedRoseLLCSpec/DetailsViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/DetailsViewControllerSpec.swift
@@ -14,7 +14,7 @@ class DetailsViewControllerSpec: QuickSpec {
                 detailsController.sellInLabel = UILabel()
                 
                 detailsController.setItem = {() in
-                    return ItemTestData.build(name: "FooBar")
+                    return ItemBuilder.build(name: "FooBar")
                 }
                 
                 
@@ -30,7 +30,7 @@ class DetailsViewControllerSpec: QuickSpec {
                 detailsController.sellInLabel = UILabel()
                 
                 detailsController.setItem = {() in
-                    var item = ItemTestData.build(name: "FooBar")
+                    var item = ItemBuilder.build(name: "FooBar")
                     item.quality = 5
                     item.sellIn = 12
                     return item
@@ -51,7 +51,7 @@ class DetailsViewControllerSpec: QuickSpec {
                 detailsController.sellInLabel = UILabel()
                 
                 detailsController.setItem = {() in
-                    var item = ItemTestData.build(name: "FooBar")
+                    var item = ItemBuilder.build(name: "FooBar")
                     item.quality = 5
                     item.sellIn = 12
                     return item

--- a/GuildedRoseLLCSpec/Fakes/FakeItemRepositorySpec.swift
+++ b/GuildedRoseLLCSpec/Fakes/FakeItemRepositorySpec.swift
@@ -21,7 +21,7 @@ class FakeItemRepositorySpec: QuickSpec {
             
             it("passes the subbed items to the callback") {
                 let itemRepository = FakeItemRepository()
-                let expectedItems = [ItemTestData.build(name: "FooBar")]
+                let expectedItems = [ItemBuilder.build(name: "FooBar")]
                 itemRepository.stub(items: expectedItems)
                 var actualItems: [Item] = []
 

--- a/GuildedRoseLLCSpec/Fakes/FakeItemRepositorySpec.swift
+++ b/GuildedRoseLLCSpec/Fakes/FakeItemRepositorySpec.swift
@@ -21,7 +21,7 @@ class FakeItemRepositorySpec: QuickSpec {
             
             it("passes the subbed items to the callback") {
                 let itemRepository = FakeItemRepository()
-                let expectedItems = [ItemBuilder.build(name: "FooBar")]
+                let expectedItems = [ItemBuilder().build()]
                 itemRepository.stub(items: expectedItems)
                 var actualItems: [Item] = []
 

--- a/GuildedRoseLLCSpec/ItemBuilderSpec.swift
+++ b/GuildedRoseLLCSpec/ItemBuilderSpec.swift
@@ -1,0 +1,24 @@
+import Quick
+import Nimble
+import GuildedRoseLLC
+import UIKit
+
+class ItemSpec: QuickSpec {
+    
+    override func spec() {
+        
+        describe("an ItemBuilder") {
+            it("sets the name, sellin, quality") {
+                let brie = ItemBuilder()
+                    .set(name: "Brie")
+                    .set(sellIn: 5)
+                    .set(quality: 7)
+                    .build()
+                
+                expect(brie.name).to(equal("Brie"))
+                expect(brie.sellIn).to(equal(5))
+                expect(brie.quality).to(equal(7))
+            }
+        }
+    }
+}

--- a/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
+++ b/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
@@ -26,7 +26,7 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
             
             it("has one item") {
                 let dataSource = ItemCollectionViewDataSource()
-                dataSource.show(items: [ItemTestData.build(name: "Foo")])
+                dataSource.show(items: [ItemBuilder.build(name: "Foo")])
                 let collectionView = buildCollectionView()
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
                 
@@ -35,12 +35,12 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
             
             it("has six items") {
                 let testData = [
-                    ItemTestData.build(name: "Foo"),
-                    ItemTestData.build(name: "Bar"),
-                    ItemTestData.build(name: "FooBar"),
-                    ItemTestData.build(name: "Lorem"),
-                    ItemTestData.build(name: "Ipsum"),
-                    ItemTestData.build(name: "VeniVidiVici"),
+                    ItemBuilder.build(name: "Foo"),
+                    ItemBuilder.build(name: "Bar"),
+                    ItemBuilder.build(name: "FooBar"),
+                    ItemBuilder.build(name: "Lorem"),
+                    ItemBuilder.build(name: "Ipsum"),
+                    ItemBuilder.build(name: "VeniVidiVici"),
                 ]
                 let dataSource = ItemCollectionViewDataSource()
                 dataSource.show(items: testData)

--- a/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
+++ b/GuildedRoseLLCSpec/ItemCollectionViewDataSourceSpec.swift
@@ -26,7 +26,7 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
             
             it("has one item") {
                 let dataSource = ItemCollectionViewDataSource()
-                dataSource.show(items: [ItemBuilder.build(name: "Foo")])
+                dataSource.show(items: [ItemBuilder().set(name: "Foo").build()])
                 let collectionView = buildCollectionView()
                 let numberOfItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
                 
@@ -35,12 +35,12 @@ class ItemCollectionViewDataSourceSpec: QuickSpec {
             
             it("has six items") {
                 let testData = [
-                    ItemBuilder.build(name: "Foo"),
-                    ItemBuilder.build(name: "Bar"),
-                    ItemBuilder.build(name: "FooBar"),
-                    ItemBuilder.build(name: "Lorem"),
-                    ItemBuilder.build(name: "Ipsum"),
-                    ItemBuilder.build(name: "VeniVidiVici"),
+                    ItemBuilder().set(name: "Foo").build(),
+                    ItemBuilder().set(name: "Bar").build(),
+                    ItemBuilder().set(name: "FooBar").build(),
+                    ItemBuilder().set(name: "Lorem").build(),
+                    ItemBuilder().set(name: "Ipsum").build(),
+                    ItemBuilder().set(name: "Veni").build(),
                 ]
                 let dataSource = ItemCollectionViewDataSource()
                 dataSource.show(items: testData)

--- a/GuildedRoseLLCSpec/ItemParserSpec.swift
+++ b/GuildedRoseLLCSpec/ItemParserSpec.swift
@@ -36,7 +36,13 @@ class ItemParserSpec : QuickSpec {
                     
                     let parsedData = ItemParser.parse(json: data)
 
-                    expect(parsedData).to(equal([ItemBuilder.build(name: "Foo", sellIn: 67, quality: 89)]))
+                    expect(parsedData).to(equal([
+                        ItemBuilder()
+                            .set(name: "Foo")
+                            .set(quality: 89)
+                            .set(sellIn: 67)
+                            .build()
+                    ]))
                 }
                 
                 it("parses a list of many named items into a list of items") {
@@ -60,7 +66,20 @@ class ItemParserSpec : QuickSpec {
                     
                     let parsedData = ItemParser.parse(json: data)
 
-                    expect(parsedData).to(equal([ItemBuilder.build(name: "Foo", sellIn: 67, quality: 89), ItemBuilder.build(name: "Bar", sellIn: 7, quality: 8)]))
+                    expect(parsedData).to(equal(
+                        [
+                            ItemBuilder()
+                            .set(name: "Foo")
+                            .set(quality: 89)
+                            .set(sellIn: 67)
+                            .build(),
+                            
+                            ItemBuilder()
+                                .set(name: "Bar")
+                                .set(quality: 8)
+                                .set(sellIn: 7)
+                                .build()
+                        ]))
                 }
                 
             }

--- a/GuildedRoseLLCSpec/ItemParserSpec.swift
+++ b/GuildedRoseLLCSpec/ItemParserSpec.swift
@@ -36,7 +36,7 @@ class ItemParserSpec : QuickSpec {
                     
                     let parsedData = ItemParser.parse(json: data)
 
-                    expect(parsedData).to(equal([Item(name: "Foo", sellIn: 67, quality: 89)]))
+                    expect(parsedData).to(equal([ItemBuilder.build(name: "Foo", sellIn: 67, quality: 89)]))
                 }
                 
                 it("parses a list of many named items into a list of items") {
@@ -60,7 +60,7 @@ class ItemParserSpec : QuickSpec {
                     
                     let parsedData = ItemParser.parse(json: data)
 
-                    expect(parsedData).to(equal([Item(name: "Foo", sellIn: 67, quality: 89), Item(name: "Bar", sellIn: 7, quality: 8)]))
+                    expect(parsedData).to(equal([ItemBuilder.build(name: "Foo", sellIn: 67, quality: 89), ItemBuilder.build(name: "Bar", sellIn: 7, quality: 8)]))
                 }
                 
             }

--- a/GuildedRoseLLCSpec/ItemRepositorySpec.swift
+++ b/GuildedRoseLLCSpec/ItemRepositorySpec.swift
@@ -9,12 +9,12 @@ class ItemRepositorySpec : QuickSpec {
         describe("getItems"){
             it("sets a list of items") {
                 let expectedTestData = [
-                    Item(name: "Foo", sellIn: 5, quality: 7),
-                    Item(name: "Bar", sellIn: 5, quality: 7),
-                    Item(name: "FooBar", sellIn: 5, quality: 7),
-                    Item(name: "Lorem", sellIn: 5, quality: 7),
-                    Item(name: "Ipsum", sellIn: 5, quality: 7),
-                    Item(name: "VeniVidiVici", sellIn: 5, quality: 7)
+                    ItemBuilder.build(name: "Foo", sellIn: 5, quality: 7),
+                    ItemBuilder.build(name: "Bar", sellIn: 5, quality: 7),
+                    ItemBuilder.build(name: "FooBar", sellIn: 5, quality: 7),
+                    ItemBuilder.build(name: "Lorem", sellIn: 5, quality: 7),
+                    ItemBuilder.build(name: "Ipsum", sellIn: 5, quality: 7),
+                    ItemBuilder.build(name: "VeniVidiVici", sellIn: 5, quality: 7)
                 ]
                 var data: [Item] = []
                 let itemRepository = StaticItemRepository()

--- a/GuildedRoseLLCSpec/ItemRepositorySpec.swift
+++ b/GuildedRoseLLCSpec/ItemRepositorySpec.swift
@@ -9,12 +9,41 @@ class ItemRepositorySpec : QuickSpec {
         describe("getItems"){
             it("sets a list of items") {
                 let expectedTestData = [
-                    ItemBuilder.build(name: "Foo", sellIn: 5, quality: 7),
-                    ItemBuilder.build(name: "Bar", sellIn: 5, quality: 7),
-                    ItemBuilder.build(name: "FooBar", sellIn: 5, quality: 7),
-                    ItemBuilder.build(name: "Lorem", sellIn: 5, quality: 7),
-                    ItemBuilder.build(name: "Ipsum", sellIn: 5, quality: 7),
-                    ItemBuilder.build(name: "VeniVidiVici", sellIn: 5, quality: 7)
+                    ItemBuilder()
+                        .set(name: "Foo")
+                        .set(sellIn: 5)
+                        .set(quality: 7)
+                        .build(),
+                    
+                    ItemBuilder()
+                        .set(name: "Bar")
+                        .set(sellIn: 5)
+                        .set(quality: 7)
+                        .build(),
+                    
+                    ItemBuilder()
+                        .set(name: "FooBar")
+                        .set(sellIn: 5)
+                        .set(quality: 7)
+                        .build(),
+                    
+                    ItemBuilder()
+                        .set(name: "Lorem")
+                        .set(sellIn: 5)
+                        .set(quality: 7)
+                        .build(),
+                    
+                    ItemBuilder()
+                        .set(name: "Ipsum")
+                        .set(sellIn: 5)
+                        .set(quality: 7)
+                        .build(),
+                    
+                    ItemBuilder()
+                        .set(name: "VeniVidiVici")
+                        .set(sellIn: 5)
+                        .set(quality: 7)
+                        .build(),
                 ]
                 var data: [Item] = []
                 let itemRepository = StaticItemRepository()

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -41,12 +41,9 @@ class ItemViewControllerSpec: QuickSpec {
             describe("viewWillAppear") {
                 it("sets the data source to a static item list") {
                     let expectedTestData = [
-                        ItemBuilder.build(name: "Foo"),
-                        ItemBuilder.build(name: "Bar"),
-                        ItemBuilder.build(name: "FooBar"),
-                        ItemBuilder.build(name: "Lorem"),
-                        ItemBuilder.build(name: "Ipsum"),
-                        ItemBuilder.build(name: "VeniVidiVici"),
+                        ItemBuilder().set(name: "Lorem").build(),
+                        ItemBuilder().set(name: "Ipsum").build(),
+                        ItemBuilder().set(name: "VeniVidiVici").build()
                     ]
                     let itemRepository = FakeItemRepository()
                     itemRepository.stub(items: expectedTestData)
@@ -82,7 +79,7 @@ class ItemViewControllerSpec: QuickSpec {
                 
                 it("shows the item collection view when there is an item") {
                     let itemRepository = FakeItemRepository()
-                    itemRepository.stub(items: [ItemBuilder.build(name: "FooBar")])
+                    itemRepository.stub(items: [ItemBuilder().build()])
                     controller.itemRepository = itemRepository
                     
                     controller.viewDidLoad()
@@ -93,7 +90,7 @@ class ItemViewControllerSpec: QuickSpec {
                 
                 it("does not show the 'no items message' when there are items") {
                     let itemRepository = FakeItemRepository()
-                    itemRepository.stub(items: [ItemBuilder.build(name: "FooBar")])
+                    itemRepository.stub(items: [ItemBuilder().build()])
                     controller.itemRepository = itemRepository
                     
                     controller.viewDidLoad()
@@ -108,7 +105,7 @@ class ItemViewControllerSpec: QuickSpec {
             var itemsController: GuildedRoseLLC.ItemsViewController!
             var detailsController: GuildedRoseLLC.ItemDetailsViewController!
             var button:UIButton!
-            let item = ItemBuilder.build(name: "foo")
+            let item = ItemBuilder().build()
             
             beforeEach {
                 itemsController = ItemsViewController()

--- a/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
+++ b/GuildedRoseLLCSpec/ItemViewControllerSpec.swift
@@ -41,12 +41,12 @@ class ItemViewControllerSpec: QuickSpec {
             describe("viewWillAppear") {
                 it("sets the data source to a static item list") {
                     let expectedTestData = [
-                        ItemTestData.build(name: "Foo"),
-                        ItemTestData.build(name: "Bar"),
-                        ItemTestData.build(name: "FooBar"),
-                        ItemTestData.build(name: "Lorem"),
-                        ItemTestData.build(name: "Ipsum"),
-                        ItemTestData.build(name: "VeniVidiVici"),
+                        ItemBuilder.build(name: "Foo"),
+                        ItemBuilder.build(name: "Bar"),
+                        ItemBuilder.build(name: "FooBar"),
+                        ItemBuilder.build(name: "Lorem"),
+                        ItemBuilder.build(name: "Ipsum"),
+                        ItemBuilder.build(name: "VeniVidiVici"),
                     ]
                     let itemRepository = FakeItemRepository()
                     itemRepository.stub(items: expectedTestData)
@@ -82,7 +82,7 @@ class ItemViewControllerSpec: QuickSpec {
                 
                 it("shows the item collection view when there is an item") {
                     let itemRepository = FakeItemRepository()
-                    itemRepository.stub(items: [ItemTestData.build(name: "FooBar")])
+                    itemRepository.stub(items: [ItemBuilder.build(name: "FooBar")])
                     controller.itemRepository = itemRepository
                     
                     controller.viewDidLoad()
@@ -93,7 +93,7 @@ class ItemViewControllerSpec: QuickSpec {
                 
                 it("does not show the 'no items message' when there are items") {
                     let itemRepository = FakeItemRepository()
-                    itemRepository.stub(items: [ItemTestData.build(name: "FooBar")])
+                    itemRepository.stub(items: [ItemBuilder.build(name: "FooBar")])
                     controller.itemRepository = itemRepository
                     
                     controller.viewDidLoad()
@@ -108,7 +108,7 @@ class ItemViewControllerSpec: QuickSpec {
             var itemsController: GuildedRoseLLC.ItemsViewController!
             var detailsController: GuildedRoseLLC.ItemDetailsViewController!
             var button:UIButton!
-            let item = ItemTestData.build(name: "foo")
+            let item = ItemBuilder.build(name: "foo")
             
             beforeEach {
                 itemsController = ItemsViewController()

--- a/GuildedRoseLLCSpec/TestData/ItemTestData.swift
+++ b/GuildedRoseLLCSpec/TestData/ItemTestData.swift
@@ -1,7 +1,0 @@
-import GuildedRoseLLC
-
-class ItemTestData {
-    static func build(name: String) -> Item {
-        return Item(name: name, sellIn: 1, quality: 2)
-    }
-}

--- a/ModelsSpec/ModelsSpec.swift
+++ b/ModelsSpec/ModelsSpec.swift
@@ -9,7 +9,7 @@ class ItemSpec: QuickSpec {
         
         describe("an Item") {
             it("sets the name, sellin, quality from a data") {
-                let brie = Item(name: "Brie", sellIn: 5, quality: 7)
+                let brie = ItemBuilder.build(name: "Brie", sellIn: 5, quality: 7)
                 
                 expect(brie.name).to(equal("Brie"))
                 expect(brie.sellIn).to(equal(5))

--- a/ModelsSpec/ModelsSpec.swift
+++ b/ModelsSpec/ModelsSpec.swift
@@ -8,18 +8,10 @@ class ItemSpec: QuickSpec {
     override func spec() {
         
         describe("an Item") {
-            it("sets the name, sellin, quality from a data") {
-                let brie = ItemBuilder.build(name: "Brie", sellIn: 5, quality: 7)
-                
-                expect(brie.name).to(equal("Brie"))
-                expect(brie.sellIn).to(equal(5))
-                expect(brie.quality).to(equal(7))
-            }
-            
             it("sets the name from json") {
                 let decoder = JSONDecoder()
-            
                 let brieJson = try? JSONSerialization.data(withJSONObject: ["id": 4, "name": "Aged Brie", "sellIn": 7, "quality": 5])
+                
                 let brie = try? decoder.decode(Item.self, from: brieJson!)
                 
                 expect(brie?.name).to(equal("Aged Brie"))


### PR DESCRIPTION
## Summary
The `builder-pattern` branch extracts out the item constructor into a builder class, to remove duplication and simplify future changes.